### PR TITLE
PYI-458: Update passport details validation to match with DCS validation

### DIFF
--- a/src/app/fields.js
+++ b/src/app/fields.js
@@ -1,7 +1,7 @@
 module.exports = {
   passportNumber: {
     type: "text",
-    validate: ["required", "numeric", { type: "exactlength", arguments: [9] }],
+    validate: ["required", "numeric", { type: "exactlength", arguments: [9] }, { type: "limit", fn: value => !value.startsWith('9')}],
   },
   surname: {
     type: "text",
@@ -27,7 +27,7 @@ module.exports = {
     validate: [
       "required",
       "date",
-      { type: "after", arguments: [new Date().toISOString().split("T")[0]] },
+      { type: "after", arguments: [new Date(new Date().getFullYear(), new Date().getMonth() - 18, new Date().getDate()).toISOString().split("T")[0]] },
     ],
   },
 };

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -3,6 +3,7 @@ passportNumber:
   validation:
     default: 'You need to supply your passport number'
     exactlength: 'UK passports are 9 digits long'
+    limit: 'UK passport numbers must be a number between 1 and 899999999'
 
 surname:
   label: Surname
@@ -24,8 +25,7 @@ expiryDate:
   legend: Expiry date
   validation:
     default: 'You need to supply the expiry date of your passport'
-    afterField: 'Expiry date must be after issue date'
-    after: 'Expiry date must be in the future'
+    after: 'Expiry date must not be more than 18 months in the past'
 
 "date-day":
   label: Day


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update the passport details validation to match DCS validation.

- Passport number must be between 1and 899999999
- Expiry date must not be more than 18 months in the past

<!-- Describe the changes in detail - the "what"-->

### Why did it change
To bring our validation in line with what the DCS service expects.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-458](https://govukverify.atlassian.net/browse/PYI-458)
