### PR TITLE
PYI-491: Change session cookie name to be unique for passport-front

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,7 +10,7 @@ const loggerConfig = {
 };
 
 const sessionConfig = {
-  cookieName: "service_session",
+  cookieName: "cri_passport_service_session",
   secret: SESSION_SECRET,
 };
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update cri-passport front's session cookie name to be unique.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
When running locally the 2 front-end apps used the same cookie name so they would override each other and session data would be lost.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-491](https://govukverify.atlassian.net/browse/PYI-491)

