### PR TITLE
PYI-585: Autofill passport form with shared attributes value if present

### DIFF
--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -19,7 +19,7 @@ module.exports = {
     const requestJWT = req.query.request;
     if (requestJWT) {
       const apiResponse = await axios.post(`${API_BASE_URL}${API_JWT_VERIFICATION_PATH}`, requestJWT);
-      req.sessionModel.set(apiResponse?.data);
+      req.session.sharedAttributes = apiResponse?.data;
     }
     next();
   },

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -61,9 +61,15 @@ describe("oauth middleware", () => {
 
   describe("addSharedAttributesToSession", () => {
     const data = {
-      claims: {
-        name: ["Danny", "Dan"]
-      }
+      names : [
+        {givenNames: ["Dan John"],    familyName: "Watson"},
+        {givenNames: ["Daniel"], familyName: "Watson"},
+        {givenNames: ["Danny, Dan"],  familyName: "Watson"},
+      ],
+      dateOfBirths:[
+        "2021-03-01",
+        "1991-03-01"
+      ]
     };
 
     beforeEach(() => {
@@ -90,7 +96,7 @@ describe("oauth middleware", () => {
     it("should save sharedAttributes to session", async function () {
       await middleware.parseSharedAttributesJWT(req, res, next);
 
-      expect(req.sessionModel.set.lastArg).to.deep.equal(data);
+      expect(req.session.sharedAttributes).to.deep.equal(data);
     });
 
     it("should call next", async function () {

--- a/src/app/oauth2/router.js
+++ b/src/app/oauth2/router.js
@@ -11,8 +11,8 @@ const {
 
 router.get(
   "/authorize",
-  addAuthParamsToSession,
   parseSharedAttributesJWT,
+  addAuthParamsToSession,
   redirectToPassportDetailsPage
 );
 router.post("/authorize", redirectToCallback);

--- a/src/app/passport/controllers/root.js
+++ b/src/app/passport/controllers/root.js
@@ -1,0 +1,20 @@
+const {Controller: BaseController} = require("hmpo-form-wizard");
+
+class RootController extends BaseController {
+  async saveValues(req, res, next) {
+    const sharedAttributes = req.session.sharedAttributes;
+    if (sharedAttributes) {
+      if (sharedAttributes?.names?.length > 0) {
+        req.journeyModel.set("surname", sharedAttributes.names[0]?.familyName)
+        req.journeyModel.set("givenNames", sharedAttributes.names[0]?.givenNames)
+      }
+
+      if (sharedAttributes.dateOfBirths.length > 0) {
+        req.journeyModel.set("dateOfBirth", sharedAttributes.dateOfBirths[0])
+      }
+    }
+    super.saveValues(req, res, next);
+  }
+}
+
+module.exports = RootController;

--- a/src/app/passport/controllers/root.test.js
+++ b/src/app/passport/controllers/root.test.js
@@ -1,0 +1,86 @@
+const RootController = require("./root");
+const {Controller: BaseController} = require("hmpo-form-wizard");
+
+describe("root controller", () => {
+  const root = new RootController({route: "/test"});
+
+  let req;
+  let res;
+  let next;
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    res = {
+      status: sinon.fake(),
+      redirect: sinon.fake(),
+      send: sinon.fake(),
+      render: sinon.fake(),
+    };
+
+    req = {
+      query: {
+        response_type: "code",
+        client_id: "s6BhdRkqt3",
+        state: "xyz",
+        redirect_uri: "https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb",
+        unusedParam: "not used",
+      },
+      session: {
+        sharedAttributes: {
+          names : [
+            {givenNames: ["Dan John"],    familyName: "Watson"},
+            {givenNames: ["Daniel"], familyName: "Watson"},
+            {givenNames: ["Danny, Dan"],  familyName: "Watson"},
+          ],
+          dateOfBirths:[
+            "2021-03-01",
+            "1991-03-01"
+          ]
+        }
+      },
+      sessionModel: {
+        get: sinon.fake(),
+        set: sinon.fake(),
+        unset: sinon.fake()
+      },
+      journeyModel: {
+        set: sinon.fake(),
+      },
+      form: {}
+    };
+
+    next = sinon.fake();
+  });
+  afterEach(() => sandbox.restore());
+
+  it("should be an instance of BaseController", () => {
+    expect(root).to.be.an.instanceof(BaseController);
+  });
+
+  it("should retrieve sharedAttributes from sessiona and store it in the journeyModel", async () => {
+    await root.saveValues(req, res, next);
+
+    expect(req.journeyModel.set.getCall(0).args[0]).to.eq("surname");
+    expect(req.journeyModel.set.getCall(0).args[1]).to.eq(req.session.sharedAttributes.names[0].familyName);
+
+    expect(req.journeyModel.set.getCall(1).args[0]).to.eq("givenNames");
+    expect(req.journeyModel.set.getCall(1).args[1]).to.eq(req.session.sharedAttributes.names[0].givenNames);
+
+    expect(req.journeyModel.set.getCall(2).args[0]).to.eq("dateOfBirth");
+    expect(req.journeyModel.set.getCall(2).args[1]).to.eq(req.session.sharedAttributes.dateOfBirths[0]);
+  });
+
+  it("should not update journeyModel if not shared attributes present", async () => {
+
+    req.session.sharedAttributes = {
+      names: [],
+      dateOfBirths: []
+    }
+
+    await root.saveValues(req, res, next);
+
+    expect(req.journeyModel.set.called, false);
+  });
+});

--- a/src/app/passport/steps.js
+++ b/src/app/passport/steps.js
@@ -1,5 +1,6 @@
 const done = require('./controllers/done');
 const details = require("./controllers/details");
+const root = require("./controllers/root");
 
 const validate = require("./controllers/validate");
 
@@ -8,6 +9,7 @@ module.exports = {
     resetJourney: true,
     entryPoint: true,
     skip: true,
+    controller: root,
     next: "details",
   },
   "/details": {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -9,7 +9,7 @@ if (!appEnv.isLocal) {
 }
 
 module.exports = {
-  API_BASE_URL: serviceConfig.coreBackAPIUrl || process.env.API_BASE_URL,
+  API_BASE_URL: serviceConfig.criPassportBackAPIUrl || process.env.API_BASE_URL,
   API_VALIDATE_PASSPORT_PATH: "/passport",
   API_JWT_VERIFICATION_PATH: "/jwt-verification",
   PORT: process.env.PORT || 3000,


### PR DESCRIPTION
Co-authored-by Lai Tang <lai.tang@digital.cabinet-office.gov.uk>
Co-authored-by Sunil Dussoye <sunil.dussoye@digital.cabinet-office.gov.uk>

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Set the returned JSON from the jwt-verification lambda within the hmpo-app session
- At the root of the hmpo-form load the shared-attribute session data and move it into the journeyModel
- Add additional unit tests

<!-- Describe the changes in detail - the "what"-->

### Why did it change
Data entered into the journeyModel is automatically picked up by the fields, so now the shared attributes values are pre-populated into the passport form.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-585](https://govukverify.atlassian.net/browse/PYI-585)

