### PR TITLE
PYI-621: Pass client_id in the header when posting to the jwt-verification api

### DIFF
--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -17,8 +17,10 @@ module.exports = {
 
   parseSharedAttributesJWT: async (req, res, next) => {
     const requestJWT = req.query.request;
+    const headers = {'client_id': req.session?.authParams?.client_id }
+
     if (requestJWT) {
-      const apiResponse = await axios.post(`${API_BASE_URL}${API_JWT_VERIFICATION_PATH}`, requestJWT);
+      const apiResponse = await axios.post(`${API_BASE_URL}${API_JWT_VERIFICATION_PATH}`, requestJWT, {headers: headers});
       req.sessionModel.set(apiResponse?.data);
     }
     next();

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -17,7 +17,7 @@ module.exports = {
 
   parseSharedAttributesJWT: async (req, res, next) => {
     const requestJWT = req.query.request;
-    const headers = {'client_id': req.session?.authParams?.client_id }
+    const headers = { 'client_id': req.session?.authParams?.client_id };
 
     if (requestJWT) {
       const apiResponse = await axios.post(`${API_BASE_URL}${API_JWT_VERIFICATION_PATH}`, requestJWT, {headers: headers});

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -133,4 +133,36 @@ describe("oauth middleware", () => {
       );
     });
   });
+
+  describe("passClientIdToJwtVerifyPostHeader", () => {
+
+    let postStub;
+    const clientId = 's6BhdRkqt3'
+    beforeEach(() => {
+      req = {
+        query: {
+          response_type: "code",
+          client_id: clientId,
+          state: "xyz",
+          redirect_uri: "https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb",
+          unusedParam: "not used",
+          request: "eyJuYW1lcyI6W3siZ2l2ZW5OYW1lcyI6WyJEYW4iXSwiZmFtaWx5TmFtZSI6IldhdHNvbiJ9LHsiZ2l2ZW5OYW1lcyI6WyJEYW5pZWwiXSwiZmFtaWx5TmFtZSI6IldhdHNvbiJ9LHsiZ2l2ZW5OYW1lcyI6WyJEYW5ueSwgRGFuIl0sImZhbWlseU5hbWUiOiJXYXRzb24ifV0sImRhdGVPZkJpcnRocyI6WyIyMDIxLTAzLTAxIiwiMTk5MS0wMy0wMSJdfQ=="
+        },
+        session: { authParams: { client_id: clientId }},
+        sessionModel: {
+          set: sinon.fake(),
+        }
+      };
+      const resolvedPromise = new Promise((resolve) => resolve({}));
+      postStub = sandbox.stub(axios, 'post').returns(resolvedPromise);
+    });
+
+    afterEach(() => sandbox.restore())
+
+    it("should pass client_id in header", async function () {
+      await middleware.parseSharedAttributesJWT(req, res, next);
+
+      expect(postStub.firstCall.args[2]?.headers?.client_id).to.be.equal(clientId)
+    });
+  });
 });


### PR DESCRIPTION
## Proposed changes

### What changed

When making call to to the jwt-verification api, the client_id sent from the Core Front request is forwarded via the header.

### Why did it change

The change enables the jwt-verification api to use the client_id and to load the corresponding certs from KMS.

### Issue tracking
- [PYI-621](https://govukverify.atlassian.net/browse/PYI-621)

