### PR TITLE
PYI-621: Fix client id header

### DIFF
--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -16,8 +16,8 @@ module.exports = {
   },
 
   parseSharedAttributesJWT: async (req, res, next) => {
-    const requestJWT = req.query.request;
-    const headers = { 'client_id': req.session?.authParams?.client_id };
+    const requestJWT = req.query?.request;
+    const headers = { 'client_id': req.query?.client_id };
 
     if (requestJWT) {
       const apiResponse = await axios.post(`${API_BASE_URL}${API_JWT_VERIFICATION_PATH}`, requestJWT, { headers: headers });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Load the client_id header value from the query params
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The parseSharedAttributesJWT middleware method is called before the authParams session method so the client_id value should be loaded from the query params rather than the passport-front session.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-621](https://govukverify.atlassian.net/browse/PYI-621)

