### PR TITLE
BAU: Handle async errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cfenv": "1.2.4",
     "dotenv": "^10.0.0",
     "express": "4.17.1",
+    "express-async-errors": "3.1.1",
     "govuk-frontend": "3.14.0",
     "hmpo-app": "1.0.2",
     "hmpo-components": "4.6.0",

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,7 @@
 require("dotenv").config();
+require("express");
+require("express-async-errors");
+
 const { setup } = require("hmpo-app");
 
 const { PORT, SESSION_SECRET } = require("./lib/config");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1379,6 +1379,11 @@ execa@^5.1.1:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
+express-async-errors@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/express-async-errors/-/express-async-errors-3.1.1.tgz#6053236d61d21ddef4892d6bd1d736889fc9da41"
+  integrity sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==
+
 express-session@^1.17.0:
   version "1.17.2"
   resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.17.2.tgz#397020374f9bf7997f891b85ea338767b30d0efd"


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Stolen from: https://github.com/alphagov/di-ipv-cri-kbv-front/pull/13

Express by default does not always handle async/await errors, resulting
in an unhandled error and a crashed server.

This fix uses the express-async-errors library to monkepatch the Express
framework to handle the errors.

### Why did it change

To stop the frontend app server crashing.
