### PR TITLE
PYIC-138: Make API_BASE_URL a variable

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,4 +5,4 @@ applications:
     buildpack: nodejs_buildpack
     command: yarn start
     env:
-      API_BASE_URL: https://e7jswiyhje.execute-api.eu-west-2.amazonaws.com/dev
+      API_BASE_URL: ((api-base-url))


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### Why did it change

So that the api gawteway can be dynamically supplied by the deploy
pipelines.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-138](https://govukverify.atlassian.net/browse/PYIC-138)
