### PR TITLE
PYIC-841: Update passport to match prototype 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
 <!-- List any related ADRs or RFCs -->
 <!-- Delete/copy as appropriate -->
 
-- [PYI-XXXX](https://govukverify.atlassian.net/browse/PYI-XXX)
+- [PYIC-XXXX](https://govukverify.atlassian.net/browse/PYIC-XXX)
 
 ## Checklists
 

--- a/src/app/passport/controllers/validate.js
+++ b/src/app/passport/controllers/validate.js
@@ -9,7 +9,7 @@ class ValidateController extends BaseController {
     const attributes = {
       passportNumber: req.sessionModel.get("passportNumber"),
       surname: req.sessionModel.get("surname"),
-      forenames: req.sessionModel.get("givenNames").split(' '),
+      forenames: req.sessionModel.get("firstName").split(' ').concat(req.sessionModel.get("middleNames").split(' ')),
       dateOfBirth: req.sessionModel.get("dateOfBirth"),
       expiryDate: req.sessionModel.get("expiryDate"),
     };

--- a/src/app/passport/controllers/validate.test.js
+++ b/src/app/passport/controllers/validate.test.js
@@ -26,7 +26,8 @@ describe("validate controller", () => {
   it("should retrieve auth code from cri-passport-back and store in session", async () => {
     req.sessionModel.set("passportNumber", "123456789");
     req.sessionModel.set("surname", "Jones Smith");
-    req.sessionModel.set("givenNames", "Dan");
+    req.sessionModel.set("firstName", "Dan");
+    req.sessionModel.set("middleNames", "Joe");
     req.sessionModel.set("dateOfBirth", "10/02/1975");
     req.sessionModel.set("expiryDate", "15/01/2035");
 
@@ -47,7 +48,8 @@ describe("validate controller", () => {
   it("should set an error object in the session if auth code is missing", async () => {
     req.sessionModel.set("passportNumber", "123456789");
     req.sessionModel.set("surname", "Jones Smith");
-    req.sessionModel.set("givenNames", "Dan");
+    req.sessionModel.set("firstName", "Dan");
+    req.sessionModel.set("middleNames", "Joe");
     req.sessionModel.set("dateOfBirth", "10/02/1975");
     req.sessionModel.set("expiryDate", "15/01/2035");
 
@@ -69,7 +71,8 @@ describe("validate controller", () => {
   it("should save error in session when error caught from cri-back", async () => {
     req.sessionModel.set("passportNumber", "123456789");
     req.sessionModel.set("surname", "Jones Smith");
-    req.sessionModel.set("givenNames", "Dan");
+    req.sessionModel.set("firstName", "Dan");
+    req.sessionModel.set("middleNames", "Joe");
     req.sessionModel.set("dateOfBirth", "10/02/1975");
     req.sessionModel.set("expiryDate", "15/01/2035");
 

--- a/src/app/passport/fields.js
+++ b/src/app/passport/fields.js
@@ -2,16 +2,24 @@ module.exports = {
   passportNumber: {
     type: "text",
     validate: ["required", "numeric", { type: "exactlength", arguments: [9] }, { type: "limit", fn: value => !value.startsWith('9')}],
+    classes: "govuk-input--width-10",
   },
   surname: {
     type: "text",
     validate: ["required"],
     journeyKey: "surname",
+    classes: "govuk-input",
   },
-  givenNames: {
+  firstName: {
     type: "text",
     validate: ["required"],
-    journeyKey: "givenNames",
+    journeyKey: "firstName",
+    classes: "govuk-input",
+  },
+  middleNames: {
+    type: "text",
+    journeyKey: "middleNames",
+    classes: "govuk-input",
   },
   dateOfBirth: {
     type: "date",

--- a/src/app/passport/steps.js
+++ b/src/app/passport/steps.js
@@ -16,7 +16,8 @@ module.exports = {
     fields: [
       "passportNumber",
       "surname",
-      "givenNames",
+      "firstName",
+      "middleNames",
       "dateOfBirth",
       "expiryDate",
     ],

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -1,5 +1,6 @@
 passportNumber:
   label: Passport number
+  hint: 'This is the 9 digit number in the top right hand corner of the photo page in your passport'
   validation:
     default: 'You need to supply your passport number'
     exactlength: 'UK passports are 9 digits long'
@@ -10,19 +11,25 @@ surname:
   validation:
     default: 'You need to supply your surname as it is printed on your passport'
 
-givenNames:
-  label: Given names
+firstName:
+  label: First name
   validation:
-    default: 'You need to supply your given names as they are printed on your passport'
+    default: 'You need to supply your first name as they are printed on your passport'
+
+middleNames:
+  label: Middle names
+  hint: 'You do not have to fill this in if you do not have any middle names'
 
 dateOfBirth:
   legend: Date of birth
+  hint: 'For example, 5 9 1973'
   validation:
     default: 'You need to supply your date of birth'
     before: 'Issue date must be in the past'
 
 expiryDate:
   legend: Expiry date
+  hint: 'For example, 27 5 2029'
   validation:
     default: 'You need to supply the expiry date of your passport'
     after: 'Expiry date must not be more than 18 months in the past'

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -1,7 +1,8 @@
 details:
-  title: Enter your passport details
+  title: Enter your details exactly as they appear on your UK passport
   content:
-    - Enter your passport details as they appear on your passport
+    - Your passport includes a lot of information that we can check to make sure that you are who you say you are.
+    - We'll check your details with the HM Passport Office to make sure your passport has not been cancelled or reported as lost or stolen.
 
 done:
   title: DCS check is complete

--- a/src/views/passport/details.html
+++ b/src/views/passport/details.html
@@ -1,2 +1,12 @@
 {% extends "form-template.njk" %}
 {% set hmpoPageKey = "details" %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+
+{% block beforeContent %}
+    {{ govukPhaseBanner({
+        tag: {
+        text: "beta"
+    },
+        html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+    }) }}
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The prototype splits given names into first name and middle names.
This concats them into a single array so within the backend its still passing the correct field forenames to the backend
Update the page template to reflect the prototype designs

_This does not meet the designs fully. For now this is acceptable as designs may change after user research._
- _The headings are using incorrect css which we have raised an issue with hmpo-form-wizard, tracked by: (https://govukverify.atlassian.net/browse/KBV-292)_
- _As we are restricted with the hmpo-form-wizard, we cannot add additional labels or headers if they do not belong to a text/check/input/radio box. We cannot also add the custom css that the prototype designs use_

### Why did it change

We want to align with the designs from the prototype

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-841](https://govukverify.atlassian.net/browse/PYIC-841)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

