### PR TITLE
PYIC-905: Return state in auth response

### DIFF
--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -44,15 +44,21 @@ module.exports = {
   redirectToCallback: async (req, res) => {
     const authCode =
       req.session["hmpo-wizard-cri-passport-front"].authorization_code;
+    const redirectUrl = new URL(decodeURIComponent(req.session.authParams.redirect_uri))
     if (authCode) {
-      res.redirect(`${req.session.authParams.redirect_uri}&code=${authCode}`);
+      redirectUrl.searchParams.append('code', authCode)
+      if (req.session.authParams.state) {
+        redirectUrl.searchParams.append('state', req.session.authParams.state)
+      }
+
+      res.redirect(redirectUrl.href);
     } else {
       const error = req.session["hmpo-wizard-cri-passport-front"].error;
       const errorCode = error?.code;
       const errorDescription = error?.description ?? error?.message;
-      res.redirect(
-        `${req.session.authParams.redirect_uri}&error=${errorCode}&error_description=${errorDescription}`
-      );
+      redirectUrl.searchParams.append('error', errorCode)
+      redirectUrl.searchParams.append('error_description', errorDescription)
+      res.redirect(redirectUrl.href);
     }
   },
 };

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -151,7 +151,20 @@ describe("oauth middleware", () => {
       await middleware.redirectToCallback(req, res);
 
       expect(res.redirect).to.have.been.calledWith(
-        `https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb?id=PassportIssuer&code=1234`
+        `https://client.example.com/cb?id=PassportIssuer&code=1234`
+      );
+    });
+
+    it("should include state in redirect param if in session", async function () {
+      req.session["hmpo-wizard-cri-passport-front"] = {
+        authorization_code: "1234",
+      };
+      req.session.authParams.state = 'state-to-return'
+
+      await middleware.redirectToCallback(req, res);
+
+      expect(res.redirect).to.have.been.calledWith(
+        `https://client.example.com/cb?id=PassportIssuer&code=1234&state=state-to-return`
       );
     });
 
@@ -166,7 +179,7 @@ describe("oauth middleware", () => {
       await middleware.redirectToCallback(req, res);
 
       expect(res.redirect).to.have.been.calledWith(
-        `https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb?id=PassportIssuer&error=permission_denied&error_description=User is not allowed`
+        `https://client.example.com/cb?id=PassportIssuer&error=permission_denied&error_description=User+is+not+allowed`
       );
     });
 
@@ -181,7 +194,7 @@ describe("oauth middleware", () => {
       await middleware.redirectToCallback(req, res);
 
       expect(res.redirect).to.have.been.calledWith(
-        `https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb?id=PassportIssuer&error=permission_denied&error_description=User is not allowed`
+        `https://client.example.com/cb?id=PassportIssuer&error=permission_denied&error_description=User+is+not+allowed`
       );
     });
   });


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Return state in auth response

### Why did it change

We need to return the state value given to us in the auth request back
to the user in the auth response. This change pulls it from the frontend
session and sets it as a query param.

This also moves to using a proper URL object to parse the redirect URL
and add the query string params. This is important because if the
redirect URL configured for the client is just a host (ie doesn't
already have any search query params), the client redirect will result
in a 404. This is because we were just appending a string to the end of
the host that began with an `&`, rather than a '?'. This is the treated
as part of the path and the core front will not be able to resolve it.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-905](https://govukverify.atlassian.net/browse/PYIC-905)