### PR TITLE
PYIC-928 - Wrap middle & first names in fieldset

### DIFF
--- a/src/views/passport/details.html
+++ b/src/views/passport/details.html
@@ -1,6 +1,7 @@
 {% extends "form-template.njk" %}
 {% set hmpoPageKey = "details" %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "hmpo-text/macro.njk" import hmpoText %}
 {% from "hmpo-form/macro.njk" import hmpoForm %}
 {% from "hmpo-date/macro.njk" import hmpoDate %}
@@ -38,25 +39,30 @@
         classes: "govuk-input"
     }) }}
 
-    <label class="govuk-label"> {{ translate("passport.passportGivenNames") }} </label>
+    {% call govukFieldset({
+        legend: {
+            text: translate("passport.passportGivenNames"),
+            classes: "govuk-!-margin-0"
+        }
+    }) %}
+        <div class="govuk-inset-text govuk-!-margin-top-2 govuk-!-padding-top-1">
+            {{ hmpoText(ctx, {
+                id: "firstName",
+                label: {
+                    classes: "govuk-label"
+                },
+                classes: "govuk-input"
+            }) }}
 
-    <div class="govuk-inset-text">
-        {{ hmpoText(ctx, {
-            id: "firstName",
-            label: {
-                classes: "govuk-label"
-            },
-            classes: "govuk-input"
-        }) }}
-
-        {{ hmpoText(ctx, {
-            id: "middleNames",
-            label: {
-                classes: "govuk-label"
-            },
-            classes: "govuk-input"
-        }) }}
-    </div>
+            {{ hmpoText(ctx, {
+                id: "middleNames",
+                label: {
+                    classes: "govuk-label"
+                },
+                classes: "govuk-input"
+            }) }}
+        </div>
+    {% endcall %}
 
     {{ hmpoDate(ctx, {
         id: "dateOfBirth",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Replaced the orphaned `label` with a `fieldset` and `legend`.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

Labels should be linked to an input - this particular label ("Given names") needed to be linked to both the "First name" and "Middle name" form fields. Grouping a number of inputs together in a fieldset makes semantic sense, allowing browsers and assistive technologies to make better sense of the form.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-928](https://govukverify.atlassian.net/browse/PYIC-928)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
