### PR TITLE
PYIC-934 Passport front error handling

### DIFF
--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -3,6 +3,7 @@ const {
   API_BASE_URL,
   API_SHARED_ATTRIBUTES_PATH,
 } = require("../../lib/config");
+const {redirectOnAuthError} = require("../shared/oauth");
 
 module.exports = {
   addAuthParamsToSession: async (req, res, next) => {
@@ -20,20 +21,20 @@ module.exports = {
 
   parseSharedAttributesJWT: async (req, res, next) => {
     const requestJWT = req.query?.request;
-    const headers = { client_id: req.query?.client_id };
+    const headers = {client_id: req.query?.client_id};
 
     try {
-      if (requestJWT) {
-        const apiResponse = await axios.post(
-          `${API_BASE_URL}${API_SHARED_ATTRIBUTES_PATH}`,
-          requestJWT,
-          { headers: headers }
-        );
-        req.session.sharedAttributes = apiResponse?.data;
-      }
-      next();
+      const apiResponse = await axios.post(
+        `${API_BASE_URL}${API_SHARED_ATTRIBUTES_PATH}`,
+        requestJWT,
+        {headers: headers}
+      )
+
+      req.session.sharedAttributes = apiResponse?.data;
+      return next();
+
     } catch (error) {
-      next(error);
+      return redirectOnAuthError(error, res, next);
     }
   },
 

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -23,6 +23,10 @@ module.exports = {
     const requestJWT = req.query?.request;
     const headers = {client_id: req.query?.client_id};
 
+    if(!requestJWT) {
+      return next(new Error('JWT Missing'));
+    }
+
     try {
       const apiResponse = await axios.post(
         `${API_BASE_URL}${API_SHARED_ATTRIBUTES_PATH}`,

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -3,7 +3,7 @@ const {
   API_BASE_URL,
   API_SHARED_ATTRIBUTES_PATH,
 } = require("../../lib/config");
-const {redirectOnAuthError} = require("../shared/oauth");
+const {redirectOnError} = require("../shared/oauth");
 
 module.exports = {
   addAuthParamsToSession: async (req, res, next) => {
@@ -38,7 +38,7 @@ module.exports = {
       return next();
 
     } catch (error) {
-      return redirectOnAuthError(error, res, next);
+      return redirectOnError(error, res, next);
     }
   },
 

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -136,7 +136,12 @@ describe("oauth middleware", () => {
     it("should next to be called with error message", async function () {
       await middleware.parseSharedAttributesJWT(req, res, next);
       expect(next).calledOnce;
-      expect(next.firstArg.message).to.include('JWT Missing');
+
+      expect(next).to.have.been.calledWith(
+        sinon.match
+          .instanceOf(Error)
+          .and(sinon.match.has("message", 'JWT Missing'))
+      );
     });
   });
 

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -123,6 +123,23 @@ describe("oauth middleware", () => {
     });
   });
 
+  describe("addSharedAttributesToSession jwt missing from request", () => {
+    afterEach(() => sandbox.restore());
+    beforeEach(() => {
+      req = {
+        query: {
+          request: ''
+        },
+      };
+    });
+
+    it("should next to be called with error message", async function () {
+      await middleware.parseSharedAttributesJWT(req, res, next);
+      expect(next).calledOnce;
+      expect(next.firstArg.message).to.include('JWT Missing');
+    });
+  });
+
   describe("addSharedAttributesToSession error in api call and error contains redirect_uri", () => {
     afterEach(() => sandbox.restore());
     beforeEach(() => {

--- a/src/app/shared/oauth.js
+++ b/src/app/shared/oauth.js
@@ -1,5 +1,5 @@
 module.exports = {
-  redirectOnAuthError: (error, res, next) => {
+  redirectOnError: (error, res, next) => {
     if (error.response && error.response.data.redirect_uri) {
       const errorData = error.response.data;
       const redirectUrl = new URL(decodeURIComponent(errorData.redirect_uri));

--- a/src/app/shared/oauth.js
+++ b/src/app/shared/oauth.js
@@ -1,0 +1,13 @@
+module.exports = {
+  redirectOnAuthError: (error, res, next) => {
+    if (error.response && error.response.data.redirect_uri) {
+      const errorData = error.response.data;
+      const redirectUrl = new URL(decodeURIComponent(errorData.redirect_uri));
+      if (errorData?.code) redirectUrl.searchParams.append('error', errorData.code)
+      if (errorData?.description) redirectUrl.searchParams.append('error_description', errorData.description)
+
+      return res.redirect(redirectUrl.href);
+    }
+    return next(error)
+  }
+}


### PR DESCRIPTION
### What changed

PYIC-994 - Update passport-front to redirect the user back to core-front if an Oauth error occurs with the JAR request and the redirect_uri is visible.

PYIC-945 - Update passport-back to return the redirect_uri value alongside the details of the error object

PYIC-947 - Update passport-front to display error page if JWT is missing cannot be found

- [PYIC-934](https://govukverify.atlassian.net/browse/PYIC-934)
- [PYIC-994](https://govukverify.atlassian.net/browse/PYIC-994)
- [PYIC-945](https://govukverify.atlassian.net/browse/PYIC-945)
- [PYIC-947](https://govukverify.atlassian.net/browse/PYIC-947)
