### PR TITLE
PYIC-951 Refactored code to call jwt-authorization-request

### DIFF
--- a/src/app/oauth2/router.js
+++ b/src/app/oauth2/router.js
@@ -3,16 +3,14 @@ const express = require("express");
 const router = express.Router();
 
 const {
-  addAuthParamsToSession,
   redirectToCallback,
   redirectToPassportDetailsPage,
-  parseSharedAttributesJWT,
+  decryptJWTAuthorizeRequest,
 } = require("./middleware");
 
 router.get(
   "/authorize",
-  parseSharedAttributesJWT,
-  addAuthParamsToSession,
+  decryptJWTAuthorizeRequest,
   redirectToPassportDetailsPage
 );
 router.get("/callback", redirectToCallback);

--- a/src/app/passport/controllers/root.js
+++ b/src/app/passport/controllers/root.js
@@ -2,15 +2,15 @@ const {Controller: BaseController} = require("hmpo-form-wizard");
 
 class RootController extends BaseController {
   async saveValues(req, res, next) {
-    const sharedAttributes = req.session.sharedAttributes;
-    if (sharedAttributes) {
-      if (sharedAttributes?.names?.length > 0) {
-        req.journeyModel.set("surname", sharedAttributes.names[0]?.familyName)
-        req.journeyModel.set("givenNames", sharedAttributes.names[0]?.givenNames)
+    const sharedClaims = req.session.JWTData.shared_claims;
+    if (sharedClaims) {
+      if (sharedClaims?.names?.length > 0) {
+        req.journeyModel.set("surname", sharedClaims.names[0]?.familyName)
+        req.journeyModel.set("givenNames", sharedClaims.names[0]?.givenNames)
       }
 
-      if (sharedAttributes?.dateOfBirths?.length > 0) {
-        req.journeyModel.set("dateOfBirth", sharedAttributes.dateOfBirths[0])
+      if (sharedClaims?.dateOfBirths?.length > 0) {
+        req.journeyModel.set("dateOfBirth", sharedClaims.dateOfBirths[0])
       }
     }
     super.saveValues(req, res, next);

--- a/src/app/passport/controllers/root.test.js
+++ b/src/app/passport/controllers/root.test.js
@@ -21,14 +21,11 @@ describe("root controller", () => {
 
     req = {
       query: {
-        response_type: "code",
         client_id: "s6BhdRkqt3",
-        state: "xyz",
-        redirect_uri: "https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb",
-        unusedParam: "not used",
       },
       session: {
-        sharedAttributes: {
+        JWTData : {
+        shared_claims: {
           names : [
             {givenNames: ["Dan John"],    familyName: "Watson"},
             {givenNames: ["Daniel"], familyName: "Watson"},
@@ -39,7 +36,7 @@ describe("root controller", () => {
             "1991-03-01"
           ]
         }
-      },
+      }},
       sessionModel: {
         get: sinon.fake(),
         set: sinon.fake(),
@@ -59,22 +56,22 @@ describe("root controller", () => {
     expect(root).to.be.an.instanceof(BaseController);
   });
 
-  it("should retrieve sharedAttributes from session and store it in the journeyModel", async () => {
+  it("should retrieve shared_claims from session and store it in the journeyModel", async () => {
     await root.saveValues(req, res, next);
 
     expect(req.journeyModel.set.getCall(0).args[0]).to.eq("surname");
-    expect(req.journeyModel.set.getCall(0).args[1]).to.eq(req.session.sharedAttributes.names[0].familyName);
+    expect(req.journeyModel.set.getCall(0).args[1]).to.eq(req.session.JWTData.shared_claims.names[0].familyName);
 
     expect(req.journeyModel.set.getCall(1).args[0]).to.eq("givenNames");
-    expect(req.journeyModel.set.getCall(1).args[1]).to.eq(req.session.sharedAttributes.names[0].givenNames);
+    expect(req.journeyModel.set.getCall(1).args[1]).to.eq(req.session.JWTData.shared_claims.names[0].givenNames);
 
     expect(req.journeyModel.set.getCall(2).args[0]).to.eq("dateOfBirth");
-    expect(req.journeyModel.set.getCall(2).args[1]).to.eq(req.session.sharedAttributes.dateOfBirths[0]);
+    expect(req.journeyModel.set.getCall(2).args[1]).to.eq(req.session.JWTData.shared_claims.dateOfBirths[0]);
   });
 
   it("should not update journeyModel if no shared attributes present", async () => {
 
-    req.session.sharedAttributes = {
+    req.session.JWTData.shared_claims = {
       names: [],
       dateOfBirths: []
     }

--- a/src/app/passport/controllers/validate.js
+++ b/src/app/passport/controllers/validate.js
@@ -18,7 +18,7 @@ class ValidateController extends BaseController {
 
     try {
       const oauthParams = {
-        ...req.session.authParams,
+        ...req.session.JWTData.authParams,
         scope: "openid",
       };
 

--- a/src/app/passport/controllers/validate.test.js
+++ b/src/app/passport/controllers/validate.test.js
@@ -16,6 +16,9 @@ describe("validate controller", () => {
     req = setup.req;
     res = setup.res;
     next = setup.next;
+
+    req.session.JWTData = {authParams: {}}
+
   });
   afterEach(() => sandbox.restore());
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -11,7 +11,7 @@ if (!appEnv.isLocal) {
 module.exports = {
   API_BASE_URL: serviceConfig.criPassportBackAPIUrl || process.env.API_BASE_URL,
   API_AUTHORIZE_PATH: "/authorization",
-  API_SHARED_ATTRIBUTES_PATH: "/shared-attributes",
+  API_JWT_AUTHORIZE_REQ_PATH: "/jwt-authorization-request",
   PORT: process.env.PORT || 3000,
   SESSION_SECRET: process.env.SESSION_SECRET,
 };


### PR DESCRIPTION
### What changed

Refactored code to call jwt-authorization-request and to store the decrypted JWT in user's session.

The decrypted data stores oAuthData in the authParams property and shared claims (formerly known as shared attributes) in the shared_claims property.

### Why did it change

To sync with passport-back's JAR changes

- [PYIC-951](https://govukverify.atlassian.net/browse/PYIC-951)

