### PR TITLE
[PYIC-1136] - Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM node:16.13.1-alpine3.15@sha256:a2c7f8ebdec79619fba306cec38150db44a45b48380d09603d3602139c5a5f92 AS builder
+
+WORKDIR /app
+RUN [ "yarn", "set", "version", "1.22.17" ]
+COPY /src ./src
+COPY package.json ./
+COPY yarn.lock ./
+
+RUN yarn install
+RUN yarn build
+
+# 'yarn install --production' does not prune test packages which are necessary
+# to build the app. So delete nod_modules and reinstall only production packages.
+RUN [ "rm", "-rf", "node_modules" ]
+RUN yarn install --production
+
+FROM node:16.13.1-alpine3.15@sha256:a2c7f8ebdec79619fba306cec38150db44a45b48380d09603d3602139c5a5f92 as final
+
+RUN ["apk", "--no-cache", "upgrade"]
+RUN ["apk", "add", "--no-cache", "tini"]
+RUN [ "yarn", "set", "version", "1.22.17" ]
+
+WORKDIR /app
+# Copy in compile assets and deps from build container
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/src ./src
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/yarn.lock ./
+
+ENV PORT 8080
+EXPOSE 8080
+
+ENTRYPOINT ["tini", "--"]
+
+CMD ["yarn", "start"]


### PR DESCRIPTION


## Proposed changes
Create Dockerfile that can build an image of the frontend code.

### What changed

Add Dockerfile using node:16.13.1-alpine3.15 to build a passport-front image

### Why did it change
Require an image for Fargate deployments

### Issue tracking

- [PYIC-1136](https://govukverify.atlassian.net/browse/PYIC-1136)

## Checklists

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

