### PR TITLE
[PYIC 1139] GitHub actions workflow build passportfront push ecr

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,50 @@
+name: Docker build, ECR push, template copy to S3 
+on:
+  push:
+    branches:
+      - main
+jobs:
+  dockerBuildAndPush:
+    name: Docker build and push
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
+        with:
+          fetch-depth: '0'
+      - name: Set up AWS creds
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.ACTIONS_ROLE_ARN }}
+          aws-region: eu-west-2
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@aaf69d68aa3fb14c1d5a6be9ac61fe15b48453a2
+      - name: Create tag
+        id: create-tag
+        run: |
+          IMAGE_TAG="${{ github.sha }}-$(date +'%Y-%m-%d-%H%M%S')"
+          echo "::set-output name=image_tag::$IMAGE_TAG"
+      - name: Build docker image
+        env:
+          IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
+        run: |
+          cd ${GITHUB_WORKSPACE} || exit 1
+          docker build -t "passport-front-build:${IMAGE_TAG}" .
+          docker tag "passport-front-build:${IMAGE_TAG}" "${{ steps.login-ecr.outputs.registry }}/passport-front-build:${IMAGE_TAG}"
+      - name: Push docker image
+        env:
+          IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
+        run: |
+          docker push "${{ steps.login-ecr.outputs.registry }}/passport-front-build:${IMAGE_TAG}"
+      - name: Create template.yaml and sha zip file and upload to artifacts S3
+      env:
+        IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
+        ARTIFACT_BUCKET: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
+      run: |
+        cd ${GITHUB_WORKSPACE}/deploy || exit 1
+        echo "${IMAGE_TAG}" > image_tag.txt
+        zip template.zip template.yaml image_tag.txt
+        aws s3 cp template.zip "s3://$ARTIFACT_BUCKET/passport/passport-front/template.zip"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Proposed changes
On every merge, Github Actions should build the docker image and push it to ECR.
Uploads the cloudformation template.yaml along with the commit sha (image_tag.txt created during GA run) to s3://di-ipv-cri-passport-build-artifacts/passport/passport-front/template.zip

### What changed

See above

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

- [PYIC-1139](https://govukverify.atlassian.net/browse/PYIC-1139)
- [PYIC-1004](https://govukverify.atlassian.net/browse/PYIC-1004)



### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
