### PR TITLE
PYIC-1163: add ecs deployment template

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -211,13 +211,13 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/ecs/${AWS::StackName}-PassportFront-ECS
       RetentionInDays: 14
-
- # ECSAccessLogsGroupSubscriptionFilter:
- #   Type: AWS::Logs::SubscriptionFilter
- #   Properties:
- #     DestinationArn: "arn:aws:logs:eu-west-2:xxxx" TO-DO
- #     FilterPattern: ""
- #     LogGroupName: !Ref ECSAccessLogsGroup
+ 
+  ECSAccessLogsGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref ECSAccessLogsGroup
 
   ECSServiceTaskDefinition:
     Type: 'AWS::ECS::TaskDefinition'
@@ -351,12 +351,12 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-PassportFront-API-GW-AccessLogs
 
-#  APIGWAccessLogsGroupSubscriptionFilter:
-#    Type: AWS::Logs::SubscriptionFilter
-#    Properties:
-#      DestinationArn: "arn:aws:logs:eu-west-2:xxxx" TO-DO
-#      FilterPattern: ""
-#      LogGroupName: !Ref APIGWAccessLogsGroup
+  APIGWAccessLogsGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref APIGWAccessLogsGroup
 
 Outputs:
   PassportFrontUrl:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1,0 +1,365 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >-
+  This creates the necessary components to deploy IPV Passport Front onto ECS
+  Fargate within an existing VPC and private subnets (provided as parameters).
+  Passport Front can be invoked via the public API Gateway on the url in the
+  PassportFrontUrl output.
+
+  The ingress route in summary is: API Gateway -> VPC link -> private ALB ->
+  Passport Front ECS Service
+
+  Passport Front egress to Passport Back's API Gateway is via a NAT Gateway, not created
+  here, which should have a route in the provided private subnets' route table.
+
+Parameters:
+  Environment:
+    Description: The name of the environment to deploy to.
+    Type: String
+    AllowedPattern: ((production)|(integration)|(staging)|(build)|(dev.*))
+  ImageTag:
+    Description: The tag of passport-front image to deploy in the task definition.
+    Type: String
+  ApiBaseUrl:
+    Description: The url for the passport internal API gateway.
+    Type: String
+  SubnetIds:
+    Description: >-
+      A comma separated list of subnet ids to create the ECS service and Load Balancer
+      within. Each subnet must have a route to a public NAT gateway since
+      the ECS Service are provisioned without a public IP address.
+      Example "sg-123, sg-567, sg-8910"
+    Type: List<String>
+  VpcId:
+    Description: >-
+      The VPC id in which to create the components.
+      Example "vpc-123"
+    Type: String
+  DesiredTaskCount:
+    Description: >-
+      The number of passport front ecs tasks to run.
+    Type: Number
+
+Conditions:
+  IsNotDevelopment: !Or
+    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, staging ]
+    - !Equals [ !Ref Environment, integration ]
+    - !Equals [ !Ref Environment, production ]
+
+Resources:
+  # Security Groups for the ECS service and load balancer
+  LoadBalancerSG:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: >-
+        Passport Front LoadBalancer Security Group
+      SecurityGroupIngress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow from anyone on port 80
+          FromPort: 80
+          IpProtocol: tcp
+          ToPort: 80
+      VpcId: !Ref VpcId
+
+  LoadBalancerSGEgressToECSSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroupEgress'
+    Properties:
+      GroupId: !GetAtt LoadBalancerSG.GroupId
+      IpProtocol: tcp
+      Description: >-
+        Egress between the Passport Front load balancer and
+        the passport front ECS security group
+      DestinationSecurityGroupId: !GetAtt ECSSecurityGroup.GroupId
+      FromPort: 8080
+      ToPort: 8080
+
+  ECSSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: >-
+        Passport Front ECS Security Group permitting outbound
+        to anywhere.
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow all outbound traffic by default
+          IpProtocol: '-1'
+      VpcId: !Ref VpcId
+
+  ECSSecurityGroupIngressFromLoadBalancer:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      IpProtocol: tcp
+      Description: >-
+        Passport Front ECS permits inbound from the Passport Front
+        load balancer.
+      FromPort: 8080
+      ToPort: 8080
+      GroupId: !GetAtt ECSSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt LoadBalancerSG.GroupId
+
+  AccessLogsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub ipv-passport-${Environment}-access-logs
+      VersioningConfiguration:
+        Status: "Enabled"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+
+  PassportFrontAccessLogsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref AccessLogsBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                - arn:aws:iam::652711504416:root
+            Action:
+              - s3:PutObject
+            Resource:
+              - !Sub arn:aws:s3:::${AccessLogsBucket}/passport-front-${Environment}/AWSLogs/${AWS::AccountId}/*
+
+  # Private Application Load Balancer
+  LoadBalancer:
+    Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
+    Properties:
+      Scheme: internal
+      SecurityGroups:
+        - !GetAtt LoadBalancerSG.GroupId
+      Subnets: !Ref SubnetIds
+      Type: application
+      LoadBalancerAttributes:
+        - Key: access_logs.s3.enabled
+          Value: true
+        - Key: access_logs.s3.bucket
+          Value: !Ref AccessLogsBucket
+        - Key: access_logs.s3.prefix
+          Value: !Sub passport-front-${Environment}
+    DependsOn:
+      - PassportFrontAccessLogsBucketPolicy
+
+  LoadBalancerListenerTargetGroupECS:
+    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
+    Properties:
+      HealthCheckEnabled: TRUE
+      HealthCheckProtocol: HTTP
+      Matcher:
+        HttpCode: 200-499
+      Port: 80
+      Protocol: HTTP
+      TargetType: ip
+      VpcId: !Ref VpcId
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: 60
+
+  LoadBalancerListener:
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
+          Type: forward
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 80
+      Protocol: HTTP
+
+  # ECS cluster, service and task definition
+  PassportFrontEcsCluster:
+    Type: 'AWS::ECS::Cluster'
+
+  PassportFrontEcsService:
+    Type: 'AWS::ECS::Service'
+    Properties:
+      Cluster: !Ref PassportFrontEcsCluster
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 50
+        DeploymentCircuitBreaker:
+          Enable: TRUE
+          Rollback: TRUE
+      DesiredCount: !Ref DesiredTaskCount
+      EnableECSManagedTags: false
+      HealthCheckGracePeriodSeconds: 60
+      LaunchType: FARGATE
+      LoadBalancers:
+        - ContainerName: app
+          ContainerPort: 8080
+          TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          SecurityGroups:
+            - !GetAtt ECSSecurityGroup.GroupId
+          Subnets: !Ref SubnetIds
+      TaskDefinition: !Ref ECSServiceTaskDefinition
+    DependsOn:
+      - LoadBalancerListener
+
+  ECSAccessLogsGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/ecs/${AWS::StackName}-PassportFront-ECS
+      RetentionInDays: 14
+
+ # ECSAccessLogsGroupSubscriptionFilter:
+ #   Type: AWS::Logs::SubscriptionFilter
+ #   Properties:
+ #     DestinationArn: "arn:aws:logs:eu-west-2:xxxx" TO-DO
+ #     FilterPattern: ""
+ #     LogGroupName: !Ref ECSAccessLogsGroup
+
+  ECSServiceTaskDefinition:
+    Type: 'AWS::ECS::TaskDefinition'
+    Properties:
+      ContainerDefinitions:
+        - Essential: true
+          Image: !If [IsNotDevelopment, !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/passport-front-${Environment}:${ImageTag}", !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/passport-front-development:${ImageTag}"]
+          Name: app
+          Environment:
+            - Name: API_BASE_URL
+              Value: !Ref ApiBaseUrl
+            - Name: EXTERNAL_WEBSITE_HOST
+              Value: !GetAtt ApiGwHttpEndpoint.ApiEndpoint
+          PortMappings:
+            - ContainerPort: 8080
+              Protocol: tcp
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group : !Ref ECSAccessLogsGroup
+              awslogs-region : !Sub ${AWS::Region}
+              awslogs-stream-prefix : !Sub passport-front-${Environment}
+      Cpu: '512'
+      ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
+      Memory: '1024'
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      TaskRoleArn: !GetAtt ECSTaskRole.Arn
+
+  ECSTaskExecutionRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+        Version: 2012-10-17
+      Policies:
+        - PolicyName: PullPassportFrontImage
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "ecr:BatchGetImage"
+                  - "ecr:GetDownloadUrlForLayer"
+                  - "ecr:GetAuthorizationToken"
+                Resource:
+                  - '*'
+              - Effect: Allow
+                Action:
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource:
+                  - !GetAtt "ECSAccessLogsGroup.Arn"
+                  - !Sub "${ECSAccessLogsGroup.Arn}:*"
+  ECSTaskRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+        Version: 2012-10-17
+
+  # Create the VPC Link to join the API Gateway to the
+  # private Load Balancer in front of Passport Front ECS
+  # Service.
+  VpcLink:
+      Type: 'AWS::ApiGatewayV2::VpcLink'
+      Properties:
+          Name: ApiGwVpcLinkToLoadBalancer
+          SubnetIds: !Ref SubnetIds
+          SecurityGroupIds: []
+
+  ApiGwHttpEndpoint:
+      Type: 'AWS::ApiGatewayV2::Api'
+      Properties:
+          Name: !Sub ipv-passport-front-${Environment}
+          ProtocolType: HTTP
+
+  ApiGwHttpEndpointIntegration:
+      Type: 'AWS::ApiGatewayV2::Integration'
+      Properties:
+        ApiId: !Ref ApiGwHttpEndpoint
+        IntegrationType: HTTP_PROXY
+        ConnectionId: !Ref VpcLink
+        ConnectionType: VPC_LINK
+        IntegrationMethod: ANY
+        IntegrationUri: !Ref LoadBalancerListener
+        PayloadFormatVersion: '1.0'
+
+  APIGWRoute:
+    Type: 'AWS::ApiGatewayV2::Route'
+    Properties:
+      ApiId: !Ref ApiGwHttpEndpoint
+      RouteKey: 'ANY /{proxy+}'
+      Target: !Join
+        - /
+        - - integrations
+          - !Ref ApiGwHttpEndpointIntegration
+
+  APIStageDefault:
+    Type: 'AWS::ApiGatewayV2::Stage'
+    Properties:
+      ApiId: !Ref ApiGwHttpEndpoint
+      StageName: $default
+      AutoDeploy: true
+      AccessLogSettings:
+        DestinationArn: !GetAtt APIGWAccessLogsGroup.Arn
+        Format: >-
+          {
+          "requestId":"$context.requestId",
+          "ip": "$context.identity.sourceIp",
+          "requestTime":"$context.requestTime",
+          "httpMethod":"$context.httpMethod",
+          "path": "$context.path",
+          "routeKey":"$context.routeKey",
+          "status":"$context.status",
+          "protocol":"$context.protocol",
+          "responseLength":"$context.responseLength"
+          }
+
+  APIGWAccessLogsGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-PassportFront-API-GW-AccessLogs
+
+#  APIGWAccessLogsGroupSubscriptionFilter:
+#    Type: AWS::Logs::SubscriptionFilter
+#    Properties:
+#      DestinationArn: "arn:aws:logs:eu-west-2:xxxx" TO-DO
+#      FilterPattern: ""
+#      LogGroupName: !Ref APIGWAccessLogsGroup
+
+Outputs:
+  PassportFrontUrl:
+    Description: >-
+      The API Gateway URL which Passport Front can be invoked on.
+    Value: !GetAtt  ApiGwHttpEndpoint.ApiEndpoint


### PR DESCRIPTION
## Proposed changes
Add ECS deploy template to create ECS cluster, it's dependencies and a Passport Frontend Task
### What changed
See above

### Why did it change
Migration to Fargate requires ECS deployment template


### Issue tracking

- [PYIC-1163](https://govukverify.atlassian.net/browse/PYIC-1163)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

