### PR TITLE
[PYIC-1216] Updated workflow to push built image to develop as latest

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -22,7 +22,9 @@ jobs:
           aws-region: eu-west-2
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@aaf69d68aa3fb14c1d5a6be9ac61fe15b48453a2
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registries: ${{ secrets.DEVELOPMENT_ACCOUNT_ID }},${{ secrets.BUILD_ACCOUNT_ID }}
       - name: Create tag
         id: create-tag
         run: |
@@ -34,12 +36,22 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE} || exit 1
           docker build -t "passport-front-build:${IMAGE_TAG}" .
-          docker tag "passport-front-build:${IMAGE_TAG}" "${{ steps.login-ecr.outputs.registry }}/passport-front-build:${IMAGE_TAG}"
-      - name: Push docker image
+          docker tag "passport-front-build:${IMAGE_TAG}" "${{ secrets.BUILD_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com/passport-front-build:${IMAGE_TAG}"
+          docker tag "passport-front-build:${IMAGE_TAG}" "${{ secrets.DEVELOPMENT_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com/passport-front-development:${IMAGE_TAG}"
+          docker tag "passport-front-build:${IMAGE_TAG}" "${{ secrets.DEVELOPMENT_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com/passport-front-development:latest"
+      - name: Push docker image to build
         env:
           IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
         run: |
-          docker push "${{ steps.login-ecr.outputs.registry }}/passport-front-build:${IMAGE_TAG}"
+          docker push "${{ secrets.BUILD_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com/passport-front-build:${IMAGE_TAG}"
+      - name: Push docker image to development
+        env:
+          ECR_REGISTRY: ${{ secrets.DEVELOPMENT_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com
+          ECR_REPOSITORY: passport-front-development
+          IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
+        run: |
+           docker push "${{ secrets.DEVELOPMENT_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com/passport-front-development:${IMAGE_TAG}"
+           docker push "${{ secrets.DEVELOPMENT_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com/passport-front-development:latest"
       - name: Create template.yaml and sha zip file and upload to artifacts S3
         env:
           IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -41,17 +41,19 @@ jobs:
           docker tag "passport-front-build:${IMAGE_TAG}" "${{ secrets.DEVELOPMENT_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com/passport-front-development:latest"
       - name: Push docker image to build
         env:
+          ECR_REGISTRY: ${{ secrets.BUILD_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com
+          ECR_REPOSITORY: passport-front-development
           IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
         run: |
-          docker push "${{ secrets.BUILD_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com/passport-front-build:${IMAGE_TAG}"
+          docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
       - name: Push docker image to development
         env:
           ECR_REGISTRY: ${{ secrets.DEVELOPMENT_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com
           ECR_REPOSITORY: passport-front-development
           IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
         run: |
-           docker push "${{ secrets.DEVELOPMENT_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com/passport-front-development:${IMAGE_TAG}"
-           docker push "${{ secrets.DEVELOPMENT_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com/passport-front-development:latest"
+           docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
+           docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
       - name: Create template.yaml and sha zip file and upload to artifacts S3
         env:
           IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}


### PR DESCRIPTION
## Proposed changes

### What changed

Modifies the github workflow to login to both development and build, in order to push the image back to the development account, tagging as 'latest'

### Why did it change

Allow developers in passport to simply pull from latest to get the 'latest' copy for development purposes

### Issue tracking
- [PYIC-1216](https://govukverify.atlassian.net/browse/PYIC-1216)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
