### PR TITLE
[PYIC-1216] Fixed name of the build repo

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Push docker image to build
         env:
           ECR_REGISTRY: ${{ secrets.BUILD_ACCOUNT_ID }}.dkr.ecr.eu-west-2.amazonaws.com
-          ECR_REPOSITORY: passport-front-development
+          ECR_REPOSITORY: passport-front-build
           IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
         run: |
           docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"


### PR DESCRIPTION
## Proposed changes

### What changed

Referred to the wrong repository name in the CI job.

### Why did it change

The build couldn't find passport-front-development repo, as it didn't exist.

### Issue tracking
- [PYIC-1216](https://govukverify.atlassian.net/browse/PYIC-1216)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
