### PR TITLE
PYIC-1042: Fix header link

### DIFF
--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -3,7 +3,7 @@ buttons:
   next: Continue
   cancel: Cancel
 govuk:
-  serviceName: Prove your identity
+  serviceName: " "
   backLink: Back
   errorSummaryTitle: There’s a problem
   error: Error


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The link was originally trying to hit the default "/" route which we never defined.
A service name is required from hmpo-components as it tries to look for it as part of the internationalisation 

### Why did it change

The "Prove your identity" header link which goes to a 404 page

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1042](https://govukverify.atlassian.net/browse/PYIC-1042)
