### PR TITLE
PYIC-1239 Export Api Gateway Id

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -363,3 +363,8 @@ Outputs:
     Description: >-
       The API Gateway URL which Passport Front can be invoked on.
     Value: !GetAtt  ApiGwHttpEndpoint.ApiEndpoint
+  PassportFrontGatewayID:
+    Description: Passport Front API Gateway ID
+    Export:
+      Name: !Sub "${AWS::StackName}-PassportFrontGatewayID"
+    Value: !Ref ApiGwHttpEndpoint


### PR DESCRIPTION


### Why did it change
Required to set up custom domain on the api gateway.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1239](https://govukverify.atlassian.net/browse/PYIC-1239)
