### PR TITLE
[PYIC-1170] Higher envs to use build ECR repo

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -224,7 +224,7 @@ Resources:
     Properties:
       ContainerDefinitions:
         - Essential: true
-          Image: !If [IsNotDevelopment, !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/passport-front-${Environment}:${ImageTag}", !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/passport-front-development:${ImageTag}"]
+          Image: !If [IsNotDevelopment, !Sub "057202043894.dkr.ecr.${AWS::Region}.amazonaws.com/passport-front-build:${ImageTag}", !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/passport-front-development:${ImageTag}"]
           Name: app
           Environment:
             - Name: API_BASE_URL


### PR DESCRIPTION
## Proposed changes

### What changed

If development, use development ECR, else use build ECR registry.

### Why did it change

ECR is only available in build, to align with secure pipelines.

### Issue tracking
- [PYIC-1170](https://govukverify.atlassian.net/browse/PYIC-1170)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
