### PR TITLE
PYIC-1135: Add technical error (unrecoverable) page

### DIFF
--- a/src/locales/en/pages.errors.yml
+++ b/src/locales/en/pages.errors.yml
@@ -1,9 +1,11 @@
 error:
-  title: Something went wrong!
+  title: Sorry, there is a problem with this service
   content:
-    - '{{ error.message }}'
-    - '{{ error | dump }}'
-    - '{% if showStack %}<pre>{{error.stack | safe}}</pre>{% endif %}'
+    - We cannot prove your identity right now.
+    - <h2 class="govuk-heading-m"> What you can do </h2>
+    - Go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
+    - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button"> Go the GOV.UK homepage </a>
+    - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link"> Contact the GOV.UK account team (opens in a new tab) </a>
 
 pageNotFound:
   title: Page not found


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->


## Proposed changes

### What changed

This uses the hmpo bootstrap error handling default.
This replaces the something went wrong error which gets displayed to a user if we dont specify a particular error for that case.

This follows the designs from [figma](https://www.figma.com/file/nglBHtbzJYEeST43Iu1jW3/PYI-DBS-Return-Journey-Mockups-(Unhappy-Paths)): 
<img width="600" alt="Screenshot 2022-05-24 at 12 08 52" src="https://user-images.githubusercontent.com/24409958/170021274-efd0487a-c265-4a61-9f53-ae5bffcfedf3.png">


passport-front:
<img width="600" alt="Screenshot 2022-05-24 at 12 07 14" src="https://user-images.githubusercontent.com/24409958/170021135-6e2f4656-9257-4025-98cb-62f667e5b35f.png">

### Why did it change

We want to show the user some type of actual error message and present a button for them to navigate elsewhere

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1135](https://govukverify.atlassian.net/browse/PYIC-XXX1135)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
