### PR TITLE
PYIC-1308 Update callback redirect url params

### DIFF
--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -48,8 +48,8 @@ module.exports = {
       res.redirect(redirectUrl.href);
     } else {
       const error = req.session["hmpo-wizard-cri-passport-front"].error;
-      const errorCode = error?.code;
-      const errorDescription = error?.description ?? error?.message;
+      const errorCode = error?.error ?? 'unknown';
+      const errorDescription = error?.error_description ?? error?.message;
       redirectUrl.searchParams.append('error', errorCode)
       redirectUrl.searchParams.append('error_description', errorDescription)
       res.redirect(redirectUrl.href);

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -229,33 +229,33 @@ describe("oauth middleware", () => {
       );
     });
 
-    it("should successfully redirect when error is provided with description field", async function () {
+    it("should successfully redirect when error is provided with error field", async function () {
       req.session["hmpo-wizard-cri-passport-front"] = {
         error: {
-          code: "permission_denied",
-          description: "User is not allowed",
+          error: "server_error",
+          error_description: "User is not allowed",
         },
       };
 
       await middleware.redirectToCallback(req, res);
 
       expect(res.redirect).to.have.been.calledWith(
-        `https://client.example.com/cb?id=PassportIssuer&error=permission_denied&error_description=User+is+not+allowed`
+        `https://client.example.com/cb?id=PassportIssuer&error=server_error&error_description=User+is+not+allowed`
       );
     });
 
-    it("should successfully redirect when error is provided with message field", async function () {
+    it("should successfully redirect when error is provided with error_description field", async function () {
       req.session["hmpo-wizard-cri-passport-front"] = {
         error: {
-          code: "permission_denied",
-          message: "User is not allowed",
+          error: "server_error",
+          error_description: "User is not allowed",
         },
       };
 
       await middleware.redirectToCallback(req, res);
 
       expect(res.redirect).to.have.been.calledWith(
-        `https://client.example.com/cb?id=PassportIssuer&error=permission_denied&error_description=User+is+not+allowed`
+        `https://client.example.com/cb?id=PassportIssuer&error=server_error&error_description=User+is+not+allowed`
       );
     });
   });

--- a/src/app/passport/controllers/validate.js
+++ b/src/app/passport/controllers/validate.js
@@ -23,11 +23,11 @@ class ValidateController extends BaseController {
       };
 
       const queryParams = this.getQueryStringParams(oauthParams);
-      
+
       const headers = { user_id: req.session.JWTData?.user_id };
 
       const apiResponse = await axios.post(
-        `${API_BASE_URL}${API_AUTHORIZE_PATH}${queryParams}`, 
+        `${API_BASE_URL}${API_AUTHORIZE_PATH}${queryParams}`,
         attributes,
         { headers: headers }
       );
@@ -37,7 +37,7 @@ class ValidateController extends BaseController {
       super.saveValues(req, res, () => {
         if (!code) {
           const error = {
-            code: "server_error",
+            error: "server_error",
             error_description:  "Failed to retrieve authorization code"
           }
           req.sessionModel.set("error", error);

--- a/src/app/passport/controllers/validate.test.js
+++ b/src/app/passport/controllers/validate.test.js
@@ -67,7 +67,7 @@ describe("validate controller", () => {
     await validate.saveValues(req, res, next);
 
     const sessionError = req.sessionModel.get("error");
-    expect(sessionError.code).to.eq("server_error");
+    expect(sessionError.error).to.eq("server_error");
     expect(sessionError.error_description).to.eq("Failed to retrieve authorization code");
   });
 


### PR DESCRIPTION
## Proposed changes

### What changed

Update the query params in the callback redirect url

### Why did it change

We are now returning oauth errors from passport-back in the shape
```
{
   "error": "server_error",
   "error_description": "What went wrong"
}
```
This updates the query params in the redirect url to match

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1308](https://govukverify.atlassian.net/browse/PYIC-1308)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed

