### PR TITLE
PYIC-1327 Update error param names

### DIFF
--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -162,7 +162,16 @@ describe("oauth middleware", () => {
     });
 
     it("should redirect using redirect_uri with error code", async function () {
-      sandbox.stub(axios, "post").throws({response: {data: {redirect_uri: 'https://xxxx/xxx.com', code: 'err'}}});
+      sandbox.stub(axios, "post").throws({
+        response: {
+          data: {
+            redirect_uri: 'https://xxxx/xxx.com',
+            oauth_error: {
+              'error': 'err'
+            }
+          }
+        }
+      });
       await middleware.decryptJWTAuthorizeRequest(req, res, next);
       expect(res.redirect).to.have.been.calledWith(`https://xxxx/xxx.com?error=err`);
     });
@@ -172,8 +181,10 @@ describe("oauth middleware", () => {
         response: {
           data: {
             redirect_uri: 'https://xxxx/xxx.com',
-            code: 'err',
-            description: 'description'
+            oauth_error: {
+              error: 'err',
+              error_description: 'description'
+            }
           }
         }
       });

--- a/src/app/shared/oauth.js
+++ b/src/app/shared/oauth.js
@@ -3,8 +3,9 @@ module.exports = {
     if (error.response && error.response.data.redirect_uri) {
       const errorData = error.response.data;
       const redirectUrl = new URL(decodeURIComponent(errorData.redirect_uri));
-      if (errorData?.code) redirectUrl.searchParams.append('error', errorData.code)
-      if (errorData?.description) redirectUrl.searchParams.append('error_description', errorData.description)
+      const oauthError = errorData.oauth_error;
+      if (oauthError?.error) redirectUrl.searchParams.append('error', oauthError.error)
+      if (oauthError?.error_description) redirectUrl.searchParams.append('error_description', oauthError.error_description)
 
       return res.redirect(redirectUrl.href);
     }


### PR DESCRIPTION
## Proposed changes

### What changed
Update the error params we're fetching for the redirect url now that passport-back is returning OAuth errors in the shape:
```
{
    "redirect_uri": "http://example.com",
    "oauth_error": {
        "error": "server_error",
        "error_description": "Description of the oauth error"
    }
}
```

### Why did it change

To update in line with backend changes

### Issue tracking
- [PYIC-1327](https://govukverify.atlassian.net/browse/PYIC-1327)

## Checklists
### Environment variables or secrets
- [X] No environment variables or secrets were added or changed
