### PR TITLE
[PYIC-1222] Add beta banner and footer links

### DIFF
--- a/src/app/passport/controllers/root.js
+++ b/src/app/passport/controllers/root.js
@@ -2,7 +2,8 @@ const {Controller: BaseController} = require("hmpo-form-wizard");
 
 class RootController extends BaseController {
   async saveValues(req, res, next) {
-    const sharedClaims = req.session.JWTData.shared_claims;
+    //const sharedClaims = req.session.JWTData.shared_claims;
+    const sharedClaims = 'testing';
     if (sharedClaims) {
       if (sharedClaims?.names?.length > 0) {
         req.journeyModel.set("surname", sharedClaims.names[0]?.familyName)

--- a/src/app/passport/controllers/root.js
+++ b/src/app/passport/controllers/root.js
@@ -2,8 +2,8 @@ const {Controller: BaseController} = require("hmpo-form-wizard");
 
 class RootController extends BaseController {
   async saveValues(req, res, next) {
-    //const sharedClaims = req.session.JWTData.shared_claims;
-    const sharedClaims = 'testing';
+    const sharedClaims = req.session.JWTData.shared_claims;
+
     if (sharedClaims) {
       if (sharedClaims?.names?.length > 0) {
         req.journeyModel.set("surname", sharedClaims.names[0]?.familyName)

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -24,6 +24,7 @@ govuk:
             text: 'Terms and conditions'
 passport:
   title: Enter your details exactly as they appear on your UK passport
+  serviceNameRequired: true
   passportInformationContext: Your passport includes a lot of information that we can check to make sure that you are who you say you are.
   checkDetailsContext: We'll check your details with the HM Passport Office to make sure your passport has not been cancelled or reported as lost  or stolen.
   passportGivenNames: Given names

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -9,8 +9,23 @@ govuk:
   error: Error
   warning: Warning
   skipLink: Skip to main content
+  footerNavItems:
+    meta:
+      items:
+          - href: 'https://signin.account.gov.uk/contact-us'
+            text: 'Help'
+          - href: 'https://signin.account.gov.uk/privacy-notice'
+            text: 'Privacy'
+          - href: 'https://www.gov.uk/help/cookies'
+            text: 'Cookies'
+          - href: 'https://signin.account.gov.uk/accessibility-statement'
+            text: 'Accessibility'
+          - href: 'https://signin.account.gov.uk/terms-and-conditions'
+            text: 'Terms and conditions'
 passport:
   title: Enter your details exactly as they appear on your UK passport
   passportInformationContext: Your passport includes a lot of information that we can check to make sure that you are who you say you are.
   checkDetailsContext: We'll check your details with the HM Passport Office to make sure your passport has not been cancelled or reported as lost  or stolen.
   passportGivenNames: Given names
+
+

--- a/src/locales/en/pages.errors.yml
+++ b/src/locales/en/pages.errors.yml
@@ -1,5 +1,6 @@
 error:
   title: Sorry, there is a problem with this service
+  serviceNameRequired: false
   content:
     - We cannot prove your identity right now.
     - <h2 class="govuk-heading-m"> What you can do </h2>
@@ -9,6 +10,7 @@ error:
 
 pageNotFound:
   title: Page not found
+  serviceNameRequired: false
   content:
     - If you typed the web address, check it’s correct.
     - If you pasted the web address, check you copied the entire address.
@@ -18,3 +20,4 @@ pageNotFound:
 
 sessionEnded:
   title: Session expired
+  serviceNameRequired: false

--- a/src/views/errors/error.html
+++ b/src/views/errors/error.html
@@ -1,2 +1,18 @@
 {% extends "hmpo-template.njk" %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% set hmpoPageKey = "errors.error" %}
+{# generate the specific footer items required for the PYI flows #}
+{% set footerNavItems = translate("govuk.footerNavItems") %}
+
+{% block beforeContent %}
+    {{ govukPhaseBanner({
+        tag: {
+        text: "beta"
+    },
+        html: 'This is a new service – your <a class="govuk-link" href="https://signin.account.gov.uk/contact-us">feedback</a> will help us to improve it.'
+    }) }}
+{% endblock %}
+
+{% block footer %}
+    {{ govukFooter( footerNavItems ) }}
+{% endblock %}

--- a/src/views/errors/error.html
+++ b/src/views/errors/error.html
@@ -1,18 +1,12 @@
-{% extends "hmpo-template.njk" %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% extends "shared/ipv-template.html" %}
 {% set hmpoPageKey = "errors.error" %}
-{# generate the specific footer items required for the PYI flows #}
-{% set footerNavItems = translate("govuk.footerNavItems") %}
 
-{% block beforeContent %}
-    {{ govukPhaseBanner({
-        tag: {
-        text: "beta"
-    },
-        html: 'This is a new service – your <a class="govuk-link" href="https://signin.account.gov.uk/contact-us">feedback</a> will help us to improve it.'
-    }) }}
-{% endblock %}
+{% block mainContent %}
+<h1 id="header" data-page="{{hmpoPageKey}}">
+{{ translate(hmpoPageKey+'.title', { default: [] }) | safe }}
+</h1>
 
-{% block footer %}
-    {{ govukFooter( footerNavItems ) }}
+{% from "hmpo-html/macro.njk" import hmpoHtml %}
+    {{ hmpoHtml(translate(hmpoPageKey + ".content", { default: [] })) }}
+
 {% endblock %}

--- a/src/views/errors/page-not-found.html
+++ b/src/views/errors/page-not-found.html
@@ -1,19 +1,12 @@
-{% extends "hmpo-template.njk" %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{% set hmpoPageKey = "errors.pageNotFound" %}
+{% extends "shared/ipv-template.html" %}
+{% set hmpoPageKey = "pages.errors.pageNotFound" %}
 
-{% block beforeContent %}
-    {{ govukPhaseBanner({
-        tag: {
-        text: "beta"
-    },
-        html: 'This is a new service – your <a class="govuk-link" href="https://signin.account.gov.uk/contact-us">feedback</a> will help us to improve it.'
-    }) }}
-{% endblock %}
+{% block mainContent %}
+<h1 id="header" data-page="{{hmpoPageKey}}">
+{{ translate(hmpoPageKey+'.title', { default: [] }) | safe }}
+</h1>
 
-{# generate the specific footer items required for the PYI flows #}
-{% set footerNavItems = translate("govuk.footerNavItems") %}
+{% from "hmpo-html/macro.njk" import hmpoHtml %}
+    {{ hmpoHtml(translate(hmpoPageKey + ".content", { default: [] })) }}
 
-{% block footer %}
-    {{ govukFooter( footerNavItems ) }}
 {% endblock %}

--- a/src/views/errors/page-not-found.html
+++ b/src/views/errors/page-not-found.html
@@ -1,2 +1,19 @@
 {% extends "hmpo-template.njk" %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% set hmpoPageKey = "errors.pageNotFound" %}
+
+{% block beforeContent %}
+    {{ govukPhaseBanner({
+        tag: {
+        text: "beta"
+    },
+        html: 'This is a new service – your <a class="govuk-link" href="https://signin.account.gov.uk/contact-us">feedback</a> will help us to improve it.'
+    }) }}
+{% endblock %}
+
+{# generate the specific footer items required for the PYI flows #}
+{% set footerNavItems = translate("govuk.footerNavItems") %}
+
+{% block footer %}
+    {{ govukFooter( footerNavItems ) }}
+{% endblock %}

--- a/src/views/errors/session-ended.html
+++ b/src/views/errors/session-ended.html
@@ -1,2 +1,20 @@
 {% extends "hmpo-template.njk" %}
 {% set hmpoPageKey = "errors.sessionEnded" %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+
+{% block beforeContent %}
+    {{ govukPhaseBanner({
+        tag: {
+        text: "beta"
+    },
+        html: 'This is a new service – your <a class="govuk-link" href="https://signin.account.gov.uk/contact-us">feedback</a> will help us to improve it.'
+    }) }}
+{% endblock %}
+
+
+{# generate the specific footer items required for the PYI flows #}
+{% set footerNavItems = translate("govuk.footerNavItems") %}
+
+{% block footer %}
+    {{ govukFooter( footerNavItems ) }}
+{% endblock %}

--- a/src/views/errors/session-ended.html
+++ b/src/views/errors/session-ended.html
@@ -1,20 +1,12 @@
-{% extends "hmpo-template.njk" %}
-{% set hmpoPageKey = "errors.sessionEnded" %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% extends "shared/ipv-template.html" %}
+{% set hmpoPageKey = "pages.errors.sessionEnded" %}
 
-{% block beforeContent %}
-    {{ govukPhaseBanner({
-        tag: {
-        text: "beta"
-    },
-        html: 'This is a new service – your <a class="govuk-link" href="https://signin.account.gov.uk/contact-us">feedback</a> will help us to improve it.'
-    }) }}
-{% endblock %}
+{% block mainContent %}
+<h1 id="header" data-page="{{hmpoPageKey}}">
+{{ translate(hmpoPageKey+'.title', { default: [] }) | safe }}
+</h1>
 
+{% from "hmpo-html/macro.njk" import hmpoHtml %}
+    {{ hmpoHtml(translate(hmpoPageKey + ".content", { default: [] })) }}
 
-{# generate the specific footer items required for the PYI flows #}
-{% set footerNavItems = translate("govuk.footerNavItems") %}
-
-{% block footer %}
-    {{ govukFooter( footerNavItems ) }}
 {% endblock %}

--- a/src/views/passport/details.html
+++ b/src/views/passport/details.html
@@ -83,3 +83,10 @@
     {% endcall %}
 
 {% endblock %}
+
+{# generate the specific footer items required for the PYI flows #}
+{% set footerNavItems = translate("govuk.footerNavItems") %}
+
+{% block footer %}
+    {{ govukFooter( footerNavItems ) }}
+{% endblock %}

--- a/src/views/passport/details.html
+++ b/src/views/passport/details.html
@@ -1,19 +1,11 @@
-{% extends "form-template.njk" %}
-{% set hmpoPageKey = "details" %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% extends "shared/ipv-template.html" %}
+{# the content for this page is controlled by locales/en/default.yml #}
+{% set hmpoPageKey = "passport" %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "hmpo-text/macro.njk" import hmpoText %}
 {% from "hmpo-form/macro.njk" import hmpoForm %}
 {% from "hmpo-date/macro.njk" import hmpoDate %}
 
-{% block beforeContent %}
-    {{ govukPhaseBanner({
-        tag: {
-        text: "beta"
-    },
-        html: 'This is a new service – your <a class="govuk-link" href="https://signin.account.gov.uk/contact-us">feedback</a> will help us to improve it.'
-    }) }}
-{% endblock %}
 
 {% block mainContent %}
     <h1 class="govuk-heading-l">

--- a/src/views/shared/ipv-template.html
+++ b/src/views/shared/ipv-template.html
@@ -1,0 +1,39 @@
+{# for this service we extend the HMPO form template nunjucks file #}
+{% extends "form-template.njk" %}
+
+{% from "govuk/components/button/macro.njk"                 import govukButton %}
+{% from "govuk/components/phase-banner/macro.njk"           import govukPhaseBanner %}
+{% from "govuk/components/warning-text/macro.njk"           import govukWarningText %}
+{% from "govuk/components/details/macro.njk"                import govukDetails %}
+
+{% set hmpoPageTitle = hmpoPageKey+".title" %}
+{% set hmpoPageTitleServiceNameRequired = hmpoPageKey+".serviceNameRequired" %}
+
+{% block pageTitle %}
+    {% if translate(hmpoPageKey+".serviceNameRequired") == 'true' %}
+        {{ translate(hmpoPageTitle) }} – Prove your identity – GOV.UK
+    {% else %}
+        {{ translate(hmpoPageTitle) }} – GOV.UK
+    {% endif %}
+{% endblock %}
+
+{# remove the cookie banner imported by the HMPO template #}
+{% block cookieBanner %}
+<!-- cookie banner code removed -->
+{% endblock %}
+
+{# the BETA banner is added to all pages using this template by default #}
+{% block beforeContent %}
+    {{ govukPhaseBanner({
+    tag: { text: "beta" },
+    html: 'This is a new service – your <a class="govuk-link" href="https://signin.account.gov.uk/contact-us">feedback</a> will help us to improve it.'
+    }) }}
+{% endblock %}
+
+
+{# generate the specific footer items required for the PYI flows #}
+
+{% set footerNavItems = translate("govuk.footerNavItems") %}
+{% block footer %}
+    {{ govukFooter( footerNavItems ) }}
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

Nunjucks design system code has been added to pages to generate the required footer links and beta banner. The footer links are managed in `default.yml`. The `passport/details.html` page is now generated by `shared/ipv-template.html`, which allows global control of page elements.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

Pages now match the designed state and provide useful links for users.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1222](https://govukverify.atlassian.net/browse/PYIC-1222)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] the global `default.yml` file was updated

### Other considerations
