### PR TITLE
PYIC-1286 Permit Log Delivery Write on Access Bucket

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -102,6 +102,7 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub ipv-passport-${Environment}-access-logs
+      AccessControl: LogDeliveryWrite
       VersioningConfiguration:
         Status: "Enabled"
       PublicAccessBlockConfiguration:


### PR DESCRIPTION
S3 access events from the Github Actions artifact bucket will be written
to the ipv-passport-<env>-access-logs bucket and we need to permit log
delivery write in the bucket's ACL.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->



### Why did it change
As per the description this is necesasary to use this bucket to capture s3 server access logs
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol

https://aws.amazon.com/premiumsupport/knowledge-center/s3-server-access-log-not-delivered/
<!-- Describe the reason these changes were made - the "why" -->
