### PR TITLE
PYIC-1290 Permit S3 Access Logs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -130,6 +130,14 @@ Resources:
               - s3:PutObject
             Resource:
               - !Sub arn:aws:s3:::${AccessLogsBucket}/passport-front-${Environment}/AWSLogs/${AWS::AccountId}/*
+          - Effect: Allow
+            Principal:
+              Service: logging.s3.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub "arn:aws:s3:::${AccessLogsBucket}/*"
+            Condition:
+              StringEquals:
+                'aws:SourceAccount': !Sub "${AWS::AccountId}"
 
   # Private Application Load Balancer
   LoadBalancer:


### PR DESCRIPTION
Update the access logs bucket policy to permit S3 access logs.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change
It makes more sense to permit `logging.s3.amazonaws.com` in the policy defined within this template than scattered throughout our code base (so I'll remove it from here: https://github.com/alphagov/di-ipv-config/blob/d0798f5400a7621673278327f2aa18e219c30b1f/cris/passport/deploy/github-identity/template.yaml#L276)
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1290](https://govukverify.atlassian.net/browse/PYIC-1290)

