### PR TITLE
PYIC-1280 Changes to circuit breaker

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -192,8 +192,10 @@ Resources:
         MaximumPercent: 200
         MinimumHealthyPercent: 50
         DeploymentCircuitBreaker:
-          Enable: TRUE
-          Rollback: TRUE
+          Enable: true
+          Rollback: true
+      DeploymentController:
+        Type: ECS
       DesiredCount: !Ref DesiredTaskCount
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
@@ -217,7 +219,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/ecs/${AWS::StackName}-PassportFront-ECS
       RetentionInDays: 14
- 
+
   ECSAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     Properties:


### PR DESCRIPTION
Changed the capitals to lowercase on the ECS Circuit breaker code 
## Proposed changes

### What changed

I removed the capitalisation of the word TRUE and made it lowercase.

### Why did it change

To prevent any errors caused by using capitals  


- [PYIC-1280](https://govukverify.atlassian.net/browse/PYIC-1280)



- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
