### PR TITLE
PYIC-1449 Include state param in error redirect url

### DIFF
--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -50,6 +50,9 @@ module.exports = {
       const errorDescription = error?.error_description ?? error?.message;
       redirectUrl.searchParams.append("error", errorCode);
       redirectUrl.searchParams.append("error_description", errorDescription);
+      if (authParams.state) {
+        redirectUrl.searchParams.append("state", authParams.state)
+      }
       res.redirect(redirectUrl.href);
     }
   },

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -51,7 +51,7 @@ module.exports = {
       redirectUrl.searchParams.append("error", errorCode);
       redirectUrl.searchParams.append("error_description", errorDescription);
       if (authParams.state) {
-        redirectUrl.searchParams.append("state", authParams.state)
+        redirectUrl.searchParams.append("state", authParams.state);
       }
       res.redirect(redirectUrl.href);
     }

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -200,6 +200,23 @@ describe("oauth middleware", () => {
         `https://xxxx/xxx.com?error=err&error_description=description`
       );
     });
+
+    it("should redirect using redirect_uri with error code, error description and state if present", async function () {
+      sandbox.stub(axios, "post").throws({
+        response: {
+          data: {
+            redirect_uri: 'https://xxxx/xxx.com',
+            oauth_error: {
+              error: 'err',
+              error_description: 'description',
+              state: 'xyz'
+            }
+          }
+        }
+      });
+      await middleware.decryptJWTAuthorizeRequest(req, res, next);
+      expect(res.redirect).to.have.been.calledWith(`https://xxxx/xxx.com?error=err&error_description=description&state=xyz`);
+    });
   });
 
   describe("redirectToPassportDetailsPage", () => {
@@ -276,6 +293,22 @@ describe("oauth middleware", () => {
 
       expect(res.redirect).to.have.been.calledWith(
         `https://client.example.com/cb?id=PassportIssuer&error=server_error&error_description=User+is+not+allowed`
+      );
+    });
+
+    it("should successfully redirect when error is provided, including setting state if it is present", async function () {
+      req.session.JWTData.authParams.state = 'xyz'
+      req.session["hmpo-wizard-cri-passport-front"] = {
+        error: {
+          error: "server_error",
+          error_description: "User is not allowed",
+        },
+      };
+
+      await middleware.redirectToCallback(req, res);
+
+      expect(res.redirect).to.have.been.calledWith(
+        `https://client.example.com/cb?id=PassportIssuer&error=server_error&error_description=User+is+not+allowed&state=xyz`
       );
     });
   });

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -206,10 +206,10 @@ describe("oauth middleware", () => {
         response: {
           data: {
             redirect_uri: 'https://xxxx/xxx.com',
+            state: 'xyz',
             oauth_error: {
               error: 'err',
               error_description: 'description',
-              state: 'xyz'
             }
           }
         }

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -205,17 +205,19 @@ describe("oauth middleware", () => {
       sandbox.stub(axios, "post").throws({
         response: {
           data: {
-            redirect_uri: 'https://xxxx/xxx.com',
-            state: 'xyz',
+            redirect_uri: "https://xxxx/xxx.com",
+            state: "xyz",
             oauth_error: {
-              error: 'err',
-              error_description: 'description',
-            }
-          }
-        }
+              error: "err",
+              error_description: "description",
+            },
+          },
+        },
       });
       await middleware.decryptJWTAuthorizeRequest(req, res, next);
-      expect(res.redirect).to.have.been.calledWith(`https://xxxx/xxx.com?error=err&error_description=description&state=xyz`);
+      expect(res.redirect).to.have.been.calledWith(
+        `https://xxxx/xxx.com?error=err&error_description=description&state=xyz`
+      );
     });
   });
 
@@ -297,7 +299,7 @@ describe("oauth middleware", () => {
     });
 
     it("should successfully redirect when error is provided, including setting state if it is present", async function () {
-      req.session.JWTData.authParams.state = 'xyz'
+      req.session.JWTData.authParams.state = "xyz";
       req.session["hmpo-wizard-cri-passport-front"] = {
         error: {
           error: "server_error",

--- a/src/app/shared/oauth.js
+++ b/src/app/shared/oauth.js
@@ -11,8 +11,8 @@ module.exports = {
           "error_description",
           oauthError.error_description
         );
-      if (oauthError?.state)
-        redirectUrl.searchParams.append('state', oauthError.state)
+      if (errorData?.state)
+        redirectUrl.searchParams.append('state', errorData.state)
 
       return res.redirect(redirectUrl.href);
     }

--- a/src/app/shared/oauth.js
+++ b/src/app/shared/oauth.js
@@ -11,6 +11,8 @@ module.exports = {
           "error_description",
           oauthError.error_description
         );
+      if (oauthError?.state)
+        redirectUrl.searchParams.append('state', oauthError.state)
 
       return res.redirect(redirectUrl.href);
     }

--- a/src/app/shared/oauth.js
+++ b/src/app/shared/oauth.js
@@ -12,7 +12,7 @@ module.exports = {
           oauthError.error_description
         );
       if (errorData?.state)
-        redirectUrl.searchParams.append('state', errorData.state)
+        redirectUrl.searchParams.append("state", errorData.state);
 
       return res.redirect(redirectUrl.href);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1068,7 +1068,7 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
+debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==


### PR DESCRIPTION
## Proposed changes

### What changed

When present set the `state` param in the redirect url for recoverable errors when calling the JwtAuthorizationRequest and AuthorizationCode endpoints. For the JwtAuthorizationRequest call passport-back will pass the state param back to us in the error response. For the AuthorizationCode call we have the state already so can pass it directly.

### Why did it change

RFC6749 (https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) requires the state param to be included in the redirect uri query alongside the error params (if it is provided in the original client authorization request)

### Issue tracking
- [PYIC-1449](https://govukverify.atlassian.net/browse/PYIC-1449)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed