### PR TITLE
PYIC-1481 fix accessibility issues

### DIFF
--- a/src/views/shared/ipv-template.html
+++ b/src/views/shared/ipv-template.html
@@ -46,16 +46,18 @@
 {% endblock %}
 
 
-{# remove the cookie banner imported by the HMPO template #}
-{% block cookieBanner %}
-<!-- cookie banner code removed -->
+{% block govukHeader %}
+{# to remediate accessibility issues the header no longer includes the service name code #}
+{# this overrides the behaviour in hmpo-template.njk and calls the 'minimal' GOV.UK header #}
+{{ govukHeader({}) }}
 {% endblock %}
+
 
 {# the BETA banner is added to all pages using this template by default #}
 {% block beforeContent %}
     {{ govukPhaseBanner({
     tag: { text: "beta" },
-    html: 'This is a new service – your <a class="govuk-link" href="https://signin.account.gov.uk/contact-us">feedback</a> will help us to improve it.'
+    html: 'This is a new service – your <a class="govuk-link" rel="noopener" target="_blank" href="https://signin.account.gov.uk/contact-us">feedback (opens in new tab)</a>  will help us to improve it.'
     }) }}
 {% endblock %}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

As with core front-end code, the passport CRI code requires:

- the empty header link to be removed - as this affects keyboard tabbing through the page
- the feedback link to open in a new window as designed and communicate this behaviour to the user 

### What changed

<!-- Describe the changes in detail - the "what"-->
`ipv-template.html` blocks have been changed and html source code modified

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To remove source code that produced inaccessible behaviours, as identified in the DAC audit.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1481](https://govukverify.atlassian.net/browse/PYIC-1481)

