### PR TITLE
PYIC-1493 Update the Target Group Healthcheck

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -195,8 +195,9 @@ Resources:
     Properties:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
+      HealthCheckPath: /healthcheck
       Matcher:
-        HttpCode: 200-499
+        HttpCode: 200
       Port: 80
       Protocol: HTTP
       TargetType: ip


### PR DESCRIPTION
Update the target groups on the front-end application load balancer to
use the `/healthcheck` endpoint which will return 200 if the server is
running. This reduces the noise from 400 http status codes in the app
logs which was always a temporary work-around.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
As above
### What changed
As above
<!-- Describe the changes in detail - the "what"-->

### Why did it change
To reduce the noise of 404 http codes in the app logs and use the purpose made `/healthcheck` endpoint. The endpoint already exists for example: https://review-p.build.account.gov.uk/healthcheck
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1493](https://govukverify.atlassian.net/browse/PYIC-1493)

