### PR TITLE
[PYIC-1416] add homepage URL and temporarily remove cookie banner

### DIFF
--- a/src/views/shared/ipv-template.html
+++ b/src/views/shared/ipv-template.html
@@ -38,6 +38,10 @@
 <!-- End Google Tag Manager -->
 {% endblock %}
 
+<!-- temporarily remove the cookie banner -->
+{% block cookieBanner %}
+{% endblock %}
+
 {% block bodyStart %}
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TK92W68"
@@ -49,7 +53,7 @@
 {% block govukHeader %}
 {# to remediate accessibility issues the header no longer includes the service name code #}
 {# this overrides the behaviour in hmpo-template.njk and calls the 'minimal' GOV.UK header #}
-{{ govukHeader({}) }}
+{{ govukHeader({ homepageUrl: "https://www.gov.uk/" }) }}
 {% endblock %}
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This change temporarily removes the cookie banner but also adds the correct URI for linking back to the GOV.uk homepage in the header

### What changed

Line 56 has an attribute added and an empty nunjucks block overrides the cookie banner code.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

So the empty cookie banner code doesn't appear on production pages.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1416](https://govukverify.atlassian.net/browse/PYIC-1416) and https://gds.slack.com/archives/C0222KXB6RM/p1656070344007499

