### PR TITLE
PYIC-1484: Send session ID to passport back

### DIFF
--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -31,7 +31,7 @@ module.exports = {
     }
   },
 
-  redirectToPassportDetailsPage: async (req, res) => {
+  redirectToPassportDetailsPage: async (_req, res) => {
     res.redirect("/passport");
   },
 

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -8,7 +8,10 @@ const { redirectOnError } = require("../shared/oauth");
 module.exports = {
   decryptJWTAuthorizeRequest: async (req, res, next) => {
     const requestJWT = req.query?.request;
-    const headers = { client_id: req.query?.client_id };
+    const headers = {
+      client_id: req.query?.client_id,
+      passport_session_id: req.session.id,
+    };
 
     if (!requestJWT) {
       return next(new Error("JWT Missing"));

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -38,7 +38,9 @@ describe("oauth middleware", () => {
           request: "someToken",
           client_id: "s6BhdRkqt3",
         },
-        session: {},
+        session: {
+          id: "asdfghjkl",
+        },
       };
 
       const resolvedPromise = new Promise((resolve) =>
@@ -51,6 +53,18 @@ describe("oauth middleware", () => {
 
     it("should save authParams to session", async function () {
       await middleware.decryptJWTAuthorizeRequest(req, res, next);
+
+      sandbox.assert.calledWith(
+        axios.post,
+        "https://example.org/subpath/jwt-authorization-request",
+        "someToken",
+        {
+          headers: {
+            client_id: "s6BhdRkqt3",
+            passport_session_id: "asdfghjkl",
+          },
+        }
+      );
       expect(req.session.JWTData.authParams).to.deep.equal(authParams);
     });
 
@@ -132,10 +146,13 @@ describe("oauth middleware", () => {
         query: {
           request: "",
         },
+        session: {
+          id: "asdfghjkl",
+        },
       };
     });
 
-    it("should next to be called with error message", async function () {
+    it("next should be called with error message", async function () {
       await middleware.decryptJWTAuthorizeRequest(req, res, next);
       expect(next).calledOnce;
 
@@ -154,6 +171,9 @@ describe("oauth middleware", () => {
         query: {
           request:
             "eyJuYW1lcyI6W3siZ2l2ZW5OYW1lcyI6WyJEYW4iXSwiZmFtaWx5TmFtZSI6IldhdHNvbiJ9LHsiZ2l2ZW5OYW1lcyI6WyJEYW5pZWwiXSwiZmFtaWx5TmFtZSI6IldhdHNvbiJ9LHsiZ2l2ZW5OYW1lcyI6WyJEYW5ueSwgRGFuIl0sImZhbWlseU5hbWUiOiJXYXRzb24ifV0sImRhdGVPZkJpcnRocyI6WyIyMDIxLTAzLTAxIiwiMTk5MS0wMy0wMSJdfQ==",
+        },
+        session: {
+          id: "asdfghjkl",
         },
       };
     });

--- a/src/app/passport/controllers/root.test.js
+++ b/src/app/passport/controllers/root.test.js
@@ -81,6 +81,6 @@ describe("root controller", () => {
 
     await root.saveValues(req, res, next);
 
-    expect(req.journeyModel.set.called, false);
+    expect(req.journeyModel.set.called).to.be.false;
   });
 });

--- a/src/app/passport/controllers/validate.js
+++ b/src/app/passport/controllers/validate.js
@@ -27,7 +27,10 @@ class ValidateController extends BaseController {
 
       const queryParams = this.getQueryStringParams(oauthParams);
 
-      const headers = { user_id: req.session.JWTData?.user_id };
+      const headers = {
+        user_id: req.session.JWTData?.user_id,
+        passport_session_id: req.session.id,
+      };
 
       const apiResponse = await axios.post(
         `${API_BASE_URL}${API_AUTHORIZE_PATH}${queryParams}`,

--- a/src/app/passport/controllers/validate.test.js
+++ b/src/app/passport/controllers/validate.test.js
@@ -17,7 +17,8 @@ describe("validate controller", () => {
     res = setup.res;
     next = setup.next;
 
-    req.session.JWTData = { authParams: {} };
+    req.session.JWTData = { authParams: {}, user_id: "a-users-id" };
+    req.session.id = "some-session-id";
   });
   afterEach(() => sandbox.restore());
 
@@ -44,6 +45,23 @@ describe("validate controller", () => {
 
     await validate.saveValues(req, res, next);
 
+    sandbox.assert.calledWith(
+      axios.post,
+      "undefined/authorization?scope=openid",
+      {
+        passportNumber: "123456789",
+        surname: "Jones Smith",
+        forenames: ["Dan", "Joe"],
+        dateOfBirth: "10/02/1975",
+        expiryDate: "15/01/2035",
+      },
+      {
+        headers: {
+          user_id: "a-users-id",
+          passport_session_id: "some-session-id",
+        },
+      }
+    );
     expect(req.session.test.authorization_code).to.eq(data.code.value);
   });
 

--- a/src/app/passport/fields.js
+++ b/src/app/passport/fields.js
@@ -1,7 +1,7 @@
 const { validators } = require("hmpo-form-wizard/lib/validation");
 
 function firstNameMiddleNameLengthValidator(
-  value,
+  _value,
   length,
   firstNameField,
   middleNameField


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Send session ID to passport back

### Why did it change

We're implementing structured logging to make it easy to link requests
in our logs. Currently we have no shared session ID available to
passport back. There is a PR open to start logging a session ID that is
passed in from passport-front, where we currently store a users session
details. Note, this is different to core which has a session table in
the backend.

This adds the session ID of the users frontend session as a header to
the authorize lambdas.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1484](https://govukverify.atlassian.net/browse/PYIC-1484)

