### PR TITLE
PYIC-1503: Add the GTM_ID and ANALYTICS_DOMAIN env vars to passport-front

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -39,6 +39,7 @@ Conditions:
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]
     - !Equals [!Ref Environment, production]
+  IsProduction: !Equals [ !Ref Environment, production ]
 
 Mappings:
   EcsConfiguration:
@@ -304,6 +305,10 @@ Resources:
                 - Environment: !Ref Environment
             - Name: EXTERNAL_WEBSITE_HOST
               Value: !GetAtt ApiGwHttpEndpoint.ApiEndpoint
+            - Name: GTM_ID
+              Value: !If [ IsProduction, "GTM-TT5HDKV", "GTM-TK92W68" ]
+            - Name: ANALYTICS_DOMAIN
+              Value: !If [ IsProduction, "account.gov.uk", !Sub "${Environment}.account.gov.uk" ]
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Set the GTM_ID & ANALYTICS_DOMAIN env vars to passport-front depending on wether it is the prod environment or not.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
These values will be used by passport-front during the setup of google tag manager
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1503](https://govukverify.atlassian.net/browse/PYIC-1503)

