### PR TITLE
PYIC-1376 - Rewrite request x-forwarded-proto header

### DIFF
--- a/.nycrc.yml
+++ b/.nycrc.yml
@@ -7,6 +7,7 @@ exclude:
   - "**/*router.js"
   - "src/app/passport/*.js"
   - "src/lib/config.js"
+  - "src/app.js"
 report-dir: coverage
 statements: 70
 branches: 80

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "express-async-errors": "^3.1.1",
     "express-session": "^1.17.3",
     "govuk-frontend": "4.0.1",
-    "hmpo-app": "2.2.1",
+    "hmpo-app": "2.3.0",
     "hmpo-components": "5.3.0",
     "hmpo-config": "2.2.0",
     "hmpo-form-wizard": "12.0.3",

--- a/src/app.js
+++ b/src/app.js
@@ -41,6 +41,12 @@ const { router } = setup({
   },
   publicDirs: ["../dist/public"],
   dev: true,
+  middlewareSetupFn: (app) => {
+    app.use(function (req, res, next) {
+      req.headers["x-forwarded-proto"] = "https";
+      next();
+    });
+  },
 });
 
 router.use("/oauth2", require("./app/oauth2/router"));


### PR DESCRIPTION
### What changed

Added middleware setup to rewrite the incoming request header value `x-forwarded-proto` to be https
Updated HMPO-App to 2.3.0 to have the ability to inject custom middleware

### Why did it change

The existing infrastructure configuration is causing the Load Balancer to forward the incorrect header `value x-fowarded-proto`.  Infrastructure cannot overwrite the value due to where the TLS termination ends and requires the app to explicitly trust that the original request is secure. 

<!-- Describe the reason these changes were made - the "why" -->
- [PYIC-1376](https://govukverify.atlassian.net/browse/PYIC-1376)
