### PR TITLE
PYIC-1563-5 Update handling response to passport check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ dist
 .aws-sam
 
 .DS_Store
+.vscode/

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -43,28 +43,8 @@ module.exports = {
   },
 
   redirectToCallback: async (req, res) => {
-    const authCode =
-      req.session["hmpo-wizard-cri-passport-front"].authorization_code;
-    const { authParams } = req.session.JWTData;
-    const redirectUrl = new URL(decodeURIComponent(authParams.redirect_uri));
-    if (authCode) {
-      redirectUrl.searchParams.append("code", authCode);
-      if (authParams.state) {
-        redirectUrl.searchParams.append("state", authParams.state);
-      }
-
-      res.redirect(redirectUrl.href);
-    } else {
-      logger.error("auth code not received in callback", { req, res });
-      const error = req.session["hmpo-wizard-cri-passport-front"].error;
-      const errorCode = error?.error ?? "unknown";
-      const errorDescription = error?.error_description ?? error?.message;
-      redirectUrl.searchParams.append("error", errorCode);
-      redirectUrl.searchParams.append("error_description", errorDescription);
-      if (authParams.state) {
-        redirectUrl.searchParams.append("state", authParams.state);
-      }
-      res.redirect(redirectUrl.href);
-    }
+    const redirectUrl =
+      req.session["hmpo-wizard-cri-passport-front"].redirect_url;
+    res.redirect(redirectUrl);
   },
 };

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -267,74 +267,16 @@ describe("oauth middleware", () => {
       };
     });
 
-    it("should successfully redirect when code is valid", async function () {
+    it("should successfully redirect with redirect_url stored in session", async function () {
       req.session["hmpo-wizard-cri-passport-front"] = {
-        authorization_code: "1234",
+        redirect_url:
+          "https://client.example.com/cb?id=PassportIssuer&code=1234",
       };
 
       await middleware.redirectToCallback(req, res);
 
       expect(res.redirect).to.have.been.calledWith(
         `https://client.example.com/cb?id=PassportIssuer&code=1234`
-      );
-    });
-
-    it("should include state in redirect param if in session", async function () {
-      req.session["hmpo-wizard-cri-passport-front"] = {
-        authorization_code: "1234",
-      };
-      req.session.JWTData.authParams.state = "state-to-return";
-
-      await middleware.redirectToCallback(req, res);
-
-      expect(res.redirect).to.have.been.calledWith(
-        `https://client.example.com/cb?id=PassportIssuer&code=1234&state=state-to-return`
-      );
-    });
-
-    it("should successfully redirect when error is provided with error field", async function () {
-      req.session["hmpo-wizard-cri-passport-front"] = {
-        error: {
-          error: "server_error",
-          error_description: "User is not allowed",
-        },
-      };
-
-      await middleware.redirectToCallback(req, res);
-
-      expect(res.redirect).to.have.been.calledWith(
-        `https://client.example.com/cb?id=PassportIssuer&error=server_error&error_description=User+is+not+allowed`
-      );
-    });
-
-    it("should successfully redirect when error is provided with error_description field", async function () {
-      req.session["hmpo-wizard-cri-passport-front"] = {
-        error: {
-          error: "server_error",
-          error_description: "User is not allowed",
-        },
-      };
-
-      await middleware.redirectToCallback(req, res);
-
-      expect(res.redirect).to.have.been.calledWith(
-        `https://client.example.com/cb?id=PassportIssuer&error=server_error&error_description=User+is+not+allowed`
-      );
-    });
-
-    it("should successfully redirect when error is provided, including setting state if it is present", async function () {
-      req.session.JWTData.authParams.state = "xyz";
-      req.session["hmpo-wizard-cri-passport-front"] = {
-        error: {
-          error: "server_error",
-          error_description: "User is not allowed",
-        },
-      };
-
-      await middleware.redirectToCallback(req, res);
-
-      expect(res.redirect).to.have.been.calledWith(
-        `https://client.example.com/cb?id=PassportIssuer&error=server_error&error_description=User+is+not+allowed&state=xyz`
       );
     });
   });

--- a/src/app/passport/controllers/details.js
+++ b/src/app/passport/controllers/details.js
@@ -3,5 +3,12 @@ const DateControllerMixin = require("hmpo-components").mixins.Date;
 
 const DateController = DateControllerMixin(BaseController);
 
-class PassportDetailsController extends DateController {}
+class PassportDetailsController extends DateController {
+  async saveValues(req, res, callback) {
+    super.saveValues(req, res, () => {
+      req.sessionModel.set("showRetryMessage", false);
+      callback();
+    });
+  }
+}
 module.exports = PassportDetailsController;

--- a/src/app/passport/controllers/details.test.js
+++ b/src/app/passport/controllers/details.test.js
@@ -4,7 +4,35 @@ const DetailsController = require("./details");
 describe("details controller", () => {
   const details = new DetailsController({ route: "/test" });
 
+  let req;
+  let res;
+  let next;
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    const setup = setupDefaultMocks();
+    req = setup.req;
+    res = setup.res;
+    next = setup.next;
+  });
+  afterEach(() => sandbox.restore());
+
   it("should be an instance of BaseController", () => {
     expect(details).to.be.an.instanceOf(BaseController);
+  });
+
+  it("should clear showRetryMessage in session", async () => {
+    req.sessionModel.set("showRetryMessage", true)
+    req.form = {
+      options: {
+        dateFields: []
+      }
+    };
+
+    await details.saveValues(req, res, next);
+
+    const showRetryMessage = req.sessionModel.get("showRetryMessage");
+    expect(showRetryMessage).to.equal(false);
   });
 });

--- a/src/app/passport/controllers/details.test.js
+++ b/src/app/passport/controllers/details.test.js
@@ -23,11 +23,11 @@ describe("details controller", () => {
   });
 
   it("should clear showRetryMessage in session", async () => {
-    req.sessionModel.set("showRetryMessage", true)
+    req.sessionModel.set("showRetryMessage", true);
     req.form = {
       options: {
-        dateFields: []
-      }
+        dateFields: [],
+      },
     };
 
     await details.saveValues(req, res, next);

--- a/src/app/passport/controllers/root.js
+++ b/src/app/passport/controllers/root.js
@@ -2,6 +2,9 @@ const { Controller: BaseController } = require("hmpo-form-wizard");
 
 class RootController extends BaseController {
   async saveValues(req, res, next) {
+    req.journeyModel.set("retry", true);
+    req.journeyModel.set("hello", "world");
+    console.log(req.sessionModel)
     const sharedClaims = req.session?.JWTData?.shared_claims;
 
     if (sharedClaims) {

--- a/src/app/passport/controllers/root.js
+++ b/src/app/passport/controllers/root.js
@@ -2,9 +2,6 @@ const { Controller: BaseController } = require("hmpo-form-wizard");
 
 class RootController extends BaseController {
   async saveValues(req, res, next) {
-    req.journeyModel.set("retry", true);
-    req.journeyModel.set("hello", "world");
-    console.log(req.sessionModel)
     const sharedClaims = req.session?.JWTData?.shared_claims;
 
     if (sharedClaims) {

--- a/src/app/passport/controllers/validate.js
+++ b/src/app/passport/controllers/validate.js
@@ -45,6 +45,7 @@ class ValidateController extends BaseController {
       );
 
       if (checkPassportResponse.data?.result === "retry") {
+        logger.info("passport retry", { req, res });
         req.sessionModel.set("showRetryMessage", true);
         return callback();
       }

--- a/src/app/passport/controllers/validate.js
+++ b/src/app/passport/controllers/validate.js
@@ -27,7 +27,7 @@ class ValidateController extends BaseController {
 
     try {
       const oauthParams = {
-        ...req.session.JWTData?.authParams,
+        ...req.session.JWTData.authParams,
         scope: "openid",
       };
 
@@ -44,9 +44,6 @@ class ValidateController extends BaseController {
         attributes,
         { headers: headers }
       );
-
-      req.sessionModel.passportResponseStatus =
-        checkPassportResponse.data?.result;
 
       if (checkPassportResponse.data?.result === "retry") {
         req.sessionModel.set("showRetryMessage", true);

--- a/src/app/passport/controllers/validate.js
+++ b/src/app/passport/controllers/validate.js
@@ -27,7 +27,7 @@ class ValidateController extends BaseController {
 
     try {
       const oauthParams = {
-        ...req.session.JWTData.authParams,
+        ...req.session.JWTData?.authParams,
         scope: "openid",
       };
 
@@ -44,10 +44,12 @@ class ValidateController extends BaseController {
         attributes,
         { headers: headers }
       );
+
       req.sessionModel.passportResponseStatus =
         checkPassportResponse.data?.result;
+
       if (checkPassportResponse.data?.result === "retry") {
-        req.session.passportResponseStatus = "retry";
+        req.sessionModel.set("showRetryMessage", true);
         return callback();
       }
 
@@ -92,11 +94,8 @@ class ValidateController extends BaseController {
   }
 
   next(req) {
-    const passportResponseStatus = req.session.passportResponseStatus;
-
-    if (passportResponseStatus === "retry") {
+    if (req.sessionModel.get("showRetryMessage")) {
       logger.info("Next is retry");
-      req.sessionModel.set("showRetryMessage", true);
       return "details";
     } else {
       logger.info("Next is callback");

--- a/src/app/passport/controllers/validate.js
+++ b/src/app/passport/controllers/validate.js
@@ -1,7 +1,7 @@
 const axios = require("axios");
 const BaseController = require("hmpo-form-wizard").Controller;
 
-const { API_BASE_URL, API_AUTHORIZE_PATH } = require("../../../lib/config");
+const { API_BASE_URL, API_CHECK_PASSPORT_PATH, API_BUILD_CLIENT_OAUTH_RESPONSE_PATH } = require("../../../lib/config");
 const logger = require("hmpo-logger").get();
 
 class ValidateController extends BaseController {
@@ -33,11 +33,21 @@ class ValidateController extends BaseController {
         passport_session_id: req.session.passportSessionId,
       };
 
-      logger.info("calling authorize lambda", { req, res });
-      const apiResponse = await axios.post(
-        `${API_BASE_URL}${API_AUTHORIZE_PATH}${queryParams}`,
+      logger.info("calling check-passport lambda", { req, res });
+      const checkPassportResponse = await axios.post(
+        `${API_BASE_URL}${API_CHECK_PASSPORT_PATH}${queryParams}`,
         attributes,
         { headers: headers }
+      );
+      // if (checkPassportResponse.data?.result === "retry" || !checkPassportResponse?.data?.code?.value) {
+      //   req.sessionModel.retry = true;
+      // }
+
+      logger.info("calling build-client-oauth-response lambda", { req, res });
+      const apiResponse = await axios.post(
+        `${API_BASE_URL}${API_BUILD_CLIENT_OAUTH_RESPONSE_PATH}`,
+        undefined,
+        { headers: { passport_session_id: req.session.passportSessionId } }
       );
 
       const code = apiResponse?.data?.code?.value;

--- a/src/app/passport/controllers/validate.test.js
+++ b/src/app/passport/controllers/validate.test.js
@@ -50,7 +50,7 @@ describe("validate controller", () => {
 
     sandbox.assert.calledWith(
       axios.post,
-      "undefined/authorization?scope=openid",
+      "/check-passport?scope=openid",
       {
         passportNumber: "123456789",
         surname: "Jones Smith",

--- a/src/app/passport/controllers/validate.test.js
+++ b/src/app/passport/controllers/validate.test.js
@@ -38,7 +38,6 @@ describe("validate controller", () => {
     req.sessionModel.set("expiryDate", "15/01/2035");
 
     const data = {
-      result: "finish",
       client: {
         redirectUrl:
           "https://client.example.com/cb?id=PassportIssuer&code=1234",
@@ -52,7 +51,7 @@ describe("validate controller", () => {
 
     sandbox.assert.calledWith(
       axios.post,
-      "undefined/check-passport?scope=openid",
+      sinon.match("/check-passport?scope=openid"),
       {
         passportNumber: "123456789",
         surname: "Jones Smith",
@@ -63,6 +62,16 @@ describe("validate controller", () => {
       {
         headers: {
           user_id: "a-users-id",
+          passport_session_id: passportSessionId,
+        },
+      }
+    );
+    sandbox.assert.calledWith(
+      axios.post,
+      sinon.match("/build-client-oauth-response"),
+      undefined,
+      {
+        headers: {
           passport_session_id: passportSessionId,
         },
       }

--- a/src/app/passport/controllers/validate.test.js
+++ b/src/app/passport/controllers/validate.test.js
@@ -121,4 +121,25 @@ describe("validate controller", () => {
       testError.response.data.error_description
     );
   });
+
+  it("should set showRetryMessage to true to show retry message", async () => {
+    req.sessionModel.set("passportNumber", "123456789");
+    req.sessionModel.set("surname", "Jones Smith");
+    req.sessionModel.set("firstName", "Dan");
+    req.sessionModel.set("middleNames", "Joe");
+    req.sessionModel.set("dateOfBirth", "10/02/1975");
+    req.sessionModel.set("expiryDate", "15/01/2035");
+
+    const data = {
+      result: "retry",
+    };
+
+    const resolvedPromise = new Promise((resolve) => resolve({ data }));
+    sandbox.stub(axios, "post").returns(resolvedPromise);
+
+    await validate.saveValues(req, res, next);
+
+    const showRetryMessage = req.sessionModel.get("showRetryMessage");
+    expect(showRetryMessage).to.equal(true);
+  });
 });

--- a/src/app/passport/controllers/validate.test.js
+++ b/src/app/passport/controllers/validate.test.js
@@ -26,7 +26,7 @@ describe("validate controller", () => {
     expect(validate).to.be.an.instanceof(BaseController);
   });
 
-  it("should retrieve auth code from cri-passport-back and store in session", async () => {
+  it("should retrieve redirect url from cri-passport-back and store in session", async () => {
     const passportSessionId = "passport123";
 
     req.sessionModel.set("passportNumber", "123456789");
@@ -38,8 +38,10 @@ describe("validate controller", () => {
     req.sessionModel.set("expiryDate", "15/01/2035");
 
     const data = {
-      code: {
-        value: "test-auth-code-12345",
+      result: "finish",
+      client: {
+        redirectUrl:
+          "https://client.example.com/cb?id=PassportIssuer&code=1234",
       },
     };
 
@@ -50,7 +52,7 @@ describe("validate controller", () => {
 
     sandbox.assert.calledWith(
       axios.post,
-      "/check-passport?scope=openid",
+      "undefined/check-passport?scope=openid",
       {
         passportNumber: "123456789",
         surname: "Jones Smith",
@@ -65,10 +67,12 @@ describe("validate controller", () => {
         },
       }
     );
-    expect(req.session.test.authorization_code).to.eq(data.code.value);
+    expect(req.session.test.redirect_url).to.eq(
+      "https://client.example.com/cb?id=PassportIssuer&code=1234"
+    );
   });
 
-  it("should set an error object in the session if auth code is missing", async () => {
+  it("should set an error object in the session if redirect url is missing", async () => {
     req.sessionModel.set("passportNumber", "123456789");
     req.sessionModel.set("surname", "Jones Smith");
     req.sessionModel.set("firstName", "Dan");
@@ -89,7 +93,7 @@ describe("validate controller", () => {
     const sessionError = req.sessionModel.get("error");
     expect(sessionError.error).to.eq("server_error");
     expect(sessionError.error_description).to.eq(
-      "Failed to retrieve authorization code"
+      "Failed to retrieve authorization redirect url"
     );
   });
 

--- a/src/app/passport/steps.js
+++ b/src/app/passport/steps.js
@@ -26,6 +26,6 @@ module.exports = {
   "/validate": {
     controller: validate,
     skip: true,
-    next: "/oauth2/callback",
+    next: validate.prototype.next,
   },
 };

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -3,6 +3,13 @@ $govuk-assets-path: "/public/";
 @import "../../../node_modules/govuk-frontend/govuk/all";
 @import "../../../node_modules/hmpo-components/all";
 
+// repainting the notification banner red for a warning state on the passport CRI [PYIC-1563]
+
+.govuk-notification-banner.passport-message {
+  border: $govuk-border-width solid $govuk-error-colour;
+  background-color: $govuk-error-colour;
+}
+
 //// Task list pattern
 //
 //.app-task-list {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -12,7 +12,8 @@ if (!appEnv.isLocal) {
 
 module.exports = {
   API_BASE_URL: serviceConfig.criPassportBackAPIUrl || process.env.API_BASE_URL,
-  API_AUTHORIZE_PATH: "/authorization",
+  API_CHECK_PASSPORT_PATH: "/check-passport",
+  API_BUILD_CLIENT_OAUTH_RESPONSE_PATH: "build-client-oauth-response",
   API_INITIALISE_SESSION_REQ_PATH: "/initialise-session",
   PORT: process.env.PORT || 3000,
   SESSION_SECRET: process.env.SESSION_SECRET,

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -13,7 +13,7 @@ if (!appEnv.isLocal) {
 module.exports = {
   API_BASE_URL: serviceConfig.criPassportBackAPIUrl || process.env.API_BASE_URL,
   API_CHECK_PASSPORT_PATH: "/check-passport",
-  API_BUILD_CLIENT_OAUTH_RESPONSE_PATH: "build-client-oauth-response",
+  API_BUILD_CLIENT_OAUTH_RESPONSE_PATH: "/build-client-oauth-response",
   API_INITIALISE_SESSION_REQ_PATH: "/initialise-session",
   PORT: process.env.PORT || 3000,
   SESSION_SECRET: process.env.SESSION_SECRET,

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -45,3 +45,13 @@ passport:
   passportInformationContext: Your passport includes a lot of information that we can check to make sure that you are who you say you are.
   checkDetailsContext: We'll check your details with the HM Passport Office to make sure your passport has not been cancelled or reported as lost  or stolen.
   passportGivenNames: Given names
+  retryTitle: Check your details match what’s on your UK passport
+  retryWarningLabel: Warning
+  retryWarningText: You will not be able to change your details again if you make a mistake this time
+  retryMessageHeading: We could not find your details
+  retryMessageParagraph1: There was a problem when we checked your details with HM Passport Office.
+  retryMessageParagraph2: "Check your details again. Remember to make sure:"
+  retryMessageList1: your passport is a UK passport
+  retryMessageList2: you’ve entered your first and middle names (‘given names’) in the right sections
+  retryMessageList3: you’ve left the middle names section blank if you do not have any middle names
+  retryMessageList4: days and months are in the right order in your date of birth and passport expiry date

--- a/src/views/passport/details.html
+++ b/src/views/passport/details.html
@@ -8,15 +8,7 @@
 
 
 {% block mainContent %}
-
-    <p>{{ ctx("errors") | length  }}</p>
-        <p>{{ values.retry }}</p>
-    <p>{{ ctx("retry") }}</p>
-
-    <p>{{ ctx("req") }}</p>
-    <p>hello</p>
-
-    {% if ctx("retry") %}
+    {% if values.showRetryMessage and not (ctx("errors") | length) %}
         {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
         {{ govukErrorSummary({

--- a/src/views/passport/details.html
+++ b/src/views/passport/details.html
@@ -8,6 +8,22 @@
 
 
 {% block mainContent %}
+
+    <p>{{ ctx("errors") | length  }}</p>
+        <p>{{ values.retry }}</p>
+    <p>{{ ctx("retry") }}</p>
+
+    <p>{{ ctx("req") }}</p>
+    <p>hello</p>
+
+    {% if ctx("retry") %}
+        {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+        {{ govukErrorSummary({
+            titleText: "Please have another go"
+        }) }}
+    {% endif %}
+
     <h1 class="govuk-heading-l">
         {{ translate("passport.title") }}
     </h1>

--- a/src/views/passport/details.html
+++ b/src/views/passport/details.html
@@ -1,7 +1,11 @@
 {% extends "shared/ipv-template.html" %}
 {# the content for this page is controlled by locales/en/default.yml #}
 {% set hmpoPageKey = "passport" %}
+
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
 {% from "hmpo-text/macro.njk" import hmpoText %}
 {% from "hmpo-form/macro.njk" import hmpoForm %}
 {% from "hmpo-date/macro.njk" import hmpoDate %}
@@ -9,18 +13,48 @@
 
 {% block mainContent %}
     {% if values.showRetryMessage and not (ctx("errors") | length) %}
-        {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-
-        {{ govukErrorSummary({
-            titleText: "Please have another go"
-        }) }}
-    {% endif %}
-
+    {# user is retrying #}
+    <h1 class="govuk-heading-l">
+        {{ translate("passport.retryTitle") }}
+    </h1>
+    {% else %}
+    {# user's first attempt #}
     <h1 class="govuk-heading-l">
         {{ translate("passport.title") }}
     </h1>
+ {% endif %}
+
+{% if values.showRetryMessage and not (ctx("errors") | length) %}
+{# user is retrying, show more information about how to complete the form #}
+{% set retryHtml %}
+<h2>{{ translate("passport.retryMessageHeading") }}</h2>
+<p>
+    {{ translate("passport.retryMessageParagraph1") }}
+</p>
+<p>
+    {{ translate("passport.retryMessageParagraph2") }}
+</p>
+<ul class="govuk-list govuk-list--bullet">
+    <li>{{ translate("passport.retryMessageList1") }}</li>
+    <li>{{ translate("passport.retryMessageList2") }}</li>
+    <li>{{ translate("passport.retryMessageList3") }}</li>
+    <li>{{ translate("passport.retryMessageList4") }}</li>
+</ul>
+{% endset %}
+
+{{ govukNotificationBanner({
+html: retryHtml,
+titleText:'Error',
+role: 'alert',
+classes:'passport-message'
+}) }}
+
+{% else %}
+{# user's first attempt #}
     <p> {{ translate("passport.passportInformationContext") }} </p>
     <p> {{ translate("passport.checkDetailsContext") }}  </p>
+{% endif %}
+
 
     {% call hmpoForm(ctx, {attributes: {onsubmit: 'window.disableFormSubmit()'} }) %}
 
@@ -88,6 +122,14 @@
             classes: "govuk-label"
         }
     }) }}
+
+    {% if values.showRetryMessage and not (ctx("errors") | length) %}
+        {# user is retrying, show warning message they have run out of attempts #}
+                {{ govukWarningText({
+                text: translate("passport.retryWarningText"),
+                iconFallbackText: translate("passport.retryWarningTitle")
+                }) }}
+    {% endif %}
 
     {{ hmpoSubmit(ctx, {id: 'submitButton'}) }}
 


### PR DESCRIPTION
## Proposed changes

### What changed

Handle new endpoints on passport back:
- First call `check-passport` with the passport details. If "retry" response received, return to details page with an error notification. If "finish" response received, continue as before.
- Second call `build-client-oauth-response` the new endpoint to generate the authorization redirect url to store in session - we now use the full redirect url constructed and returned by the backend rather than generating it in front itself given just the authorization code.

### Why did it change

To handle the changes on the backend for the new retries journey

### Issue tracking
- [PYIC-1563](https://govukverify.atlassian.net/browse/PYIC-1563)
- [PYIC-1564](https://govukverify.atlassian.net/browse/PYIC-1564)
- [PYIC-1565](https://govukverify.atlassian.net/browse/PYIC-1565)
