### PR TITLE
BAU Fix stack drift

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -41,6 +41,15 @@ Conditions:
     - !Equals [!Ref Environment, production]
   IsProduction: !Equals [ !Ref Environment, production ]
 
+  #Temporary to fix stack drift.
+  IsNotStagingOrDevelopment: !Not
+    - !Or 
+      - !Equals [ !Ref Environment, "development-a"]
+      - !Equals [ !Ref Environment, "development-b"]
+      - !Equals [ !Ref Environment, "development-c"]
+      - !Equals [ !Ref Environment, "staging"]
+
+
 Mappings:
   EcsConfiguration:
     "322814139578": # development
@@ -275,7 +284,9 @@ Resources:
 
   ECSAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
+    # Temporary to resolve stack drift
+    #Condition: IsNotDevelopment
+    Condition: IsNotStagingOrDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
@@ -453,7 +464,9 @@ Resources:
 
   APIGWAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
+    # Temporary to resolve stack drift
+    #Condition: IsNotDevelopment
+    Condition: IsNotStagingOrDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""


### PR DESCRIPTION
Temporarily remove some log group subscription filters from staging
because they were deleted manually by mistake. This change will make
CFN's state align with reality, then this can be reverted and CFN will
recreate the resources.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
As above.
### What changed
As above.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Some logging is broken from passport front in staging. This will fix the drift as reported below.

```
GDS11321:drift dan.worth$ aws-vault exec passport-staging-admin -- ./detect_drift.sh passport-front-staging | grep DELETED
APIGWAccessLogsGroupSubscriptionFilter  AWS::Logs::SubscriptionFilter              DELETED
ECSAccessLogsGroupSubscriptionFilter    AWS::Logs::SubscriptionFilter              DELETED
```
<!-- Describe the reason these changes were made - the "why" -->

