### PR TITLE
Revert "BAU Fix stack drift"

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -41,15 +41,6 @@ Conditions:
     - !Equals [!Ref Environment, production]
   IsProduction: !Equals [ !Ref Environment, production ]
 
-  #Temporary to fix stack drift.
-  IsNotStagingOrDevelopment: !Not
-    - !Or 
-      - !Equals [ !Ref Environment, "development-a"]
-      - !Equals [ !Ref Environment, "development-b"]
-      - !Equals [ !Ref Environment, "development-c"]
-      - !Equals [ !Ref Environment, "staging"]
-
-
 Mappings:
   EcsConfiguration:
     "322814139578": # development
@@ -284,9 +275,7 @@ Resources:
 
   ECSAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    # Temporary to resolve stack drift
-    #Condition: IsNotDevelopment
-    Condition: IsNotStagingOrDevelopment
+    Condition: IsNotDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
@@ -464,9 +453,7 @@ Resources:
 
   APIGWAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    # Temporary to resolve stack drift
-    #Condition: IsNotDevelopment
-    Condition: IsNotStagingOrDevelopment
+    Condition: IsNotDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""


### PR DESCRIPTION
This reverts commit 6c8d319fb22bb42504e614cccaa780c5733a5bb3.

The commit being reverted temporarily removed two log group subscription
filters from staging in order to bring the CFN stack state back into alignment
with reality. Reverting the commit will make CFN recreate them and thus
fix the drift.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
As above
### What changed
As above
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The commit being reverted has been deployed https://cd.gds-reliability.engineering/teams/di-ipv/pipelines/cri-passport-deploy-to-production/jobs/deploy-passport-front-ecs/builds/58#L62c5845d:3

There is no more drift caused by deleted resources, thus reverting the commit will now make CFN recreate the missing log group subscription filters and we'll see logs in Splunk again.
```
GDS11321:drift dan.worth$ aws-vault exec passport-staging-admin -- ./detect_drift.sh passport-front-staging
Touch your YubiKey...
Detecting drift for passport-front-staging
Waiting for detection to complete: request id cd6c2a10-040c-11ed-a418-0a185e5be6a6
Detection status: DETECTION_IN_PROGRESS
waiting 10 seconds for drift detection to complete
Detection status: DETECTION_IN_PROGRESS
waiting 10 seconds for drift detection to complete
Detection status: DETECTION_COMPLETE
Drift detection complete

LogicalId                           ResourceType                               Status
APIGWAccessLogsGroup                AWS::Logs::LogGroup                        MODIFIED
AccessLogsBucket                    AWS::S3::Bucket                            IN_SYNC
ApiGwHttpEndpoint                   AWS::ApiGatewayV2::Api                     IN_SYNC
ECSAccessLogsGroup                  AWS::Logs::LogGroup                        MODIFIED
ECSSecurityGroup                    AWS::EC2::SecurityGroup                    IN_SYNC
ECSServiceTaskDefinition            AWS::ECS::TaskDefinition                   IN_SYNC
ECSTaskExecutionRole                AWS::IAM::Role                             IN_SYNC
ECSTaskRole                         AWS::IAM::Role                             IN_SYNC
LoadBalancer                        AWS::ElasticLoadBalancingV2::LoadBalancer  IN_SYNC
LoadBalancerListener                AWS::ElasticLoadBalancingV2::Listener      IN_SYNC
LoadBalancerListenerTargetGroupECS  AWS::ElasticLoadBalancingV2::TargetGroup   IN_SYNC
LoadBalancerSG                      AWS::EC2::SecurityGroup                    IN_SYNC
PassportFrontEcsCluster             AWS::ECS::Cluster                          MODIFIED
PassportFrontEcsService             AWS::ECS::Service                          MODIFIED
PassportFrontSessionsTable          AWS::DynamoDB::Table                       IN_SYNC
VpcLink                             AWS::ApiGatewayV2::VpcLink                 MODIFIED
```
<!-- Describe the reason these changes were made - the "why" -->

