### PR TITLE
BAU Update deploy script to allow passing in env arg

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -2,13 +2,13 @@
 
 #### Purpose
 
-This script will build the passport-front docker image from your local source code and push the image into the development account's `passport-front-development` registry. It will then update your passport-front stack to use the image.
+This script will build the passport-front docker image from your local source code and push the image into the development account's `passport-front-development-{ENV}` registry. It will then update your passport-front stack to use the image. Specify which of the 3 dev envs you wish to deploy to by providing a, b or c as the first argument.
 
 ### How it works
 
 - Run the `deploy_to_dev_env.sh` within a shell with AWS credentials to describe/update stacks and push images in the IPV Passport Development account (most developers have an admin role in the development account which will work), for example:
 
-  `aws-vault exec passport-dev -- ./deploy_to_dev_env.sh`
+  `aws-vault exec passport-dev -- ./deploy_to_dev_env.sh a`
 
 - The script will check that the stack exists and you have the necessary binaries installed and processes running.
 - Builds the passport-front docker image with the tag of `<epoch seconds>`

--- a/utils/deploy_to_dev_env.sh
+++ b/utils/deploy_to_dev_env.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
+# Use the first argument to specify the env to deploy to - a, b or c.
 # This script must be run in a shell with sufficient AWS access.
-# This can be achieved by using aws-vault and an amin role for example
-# aws-vault exec passport-dev -- ./deploy_to_dev_env.sh
+# This can be achieved by using aws-vault and a role for example:
+# aws-vault exec passport-dev -- ./deploy_to_dev_env.sh a
+
+if [ $# -ne 1 ]
+  then
+    echo "Exactly one argument must be supplied: the env you wish to deploy to - a, b or c"
+    exit 1
+fi
 
 if ! which jq >/dev/null; then
   echo "Please install jq to use this script"
@@ -13,7 +20,7 @@ if ! docker info > /dev/null 2>&1 ; then
   exit 1
 fi
 
-STACK_NAME="passport-front-development"
+STACK_NAME="passport-front-development-$1"
 DEV_IMAGE_TAG="$(date +%s)"
 
 if ! aws cloudformation describe-stacks \


### PR DESCRIPTION

## Proposed changes

### What changed

Allow passing one of a,b,c as first arg to specify which of the now 3 passport dev envs to deploy to
eg. `aws-vault exec passport-dev -- ./deploy_to_dev_env.sh b`

### Why did it change

We now have 3 passport development envs
