### PR TITLE
PYIC-1610 stop storing authParams in session, store only shared_claims

### DIFF
--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -25,9 +25,9 @@ module.exports = {
       );
       logger.info("response received from JWT authorize lambda", { req, res });
 
-      let { passportSessionId, ...JWTData } = apiResponse.data;
+      let { passportSessionId, shared_claims } = apiResponse.data;
 
-      req.session.JWTData = JWTData;
+      req.session.shared_claims = shared_claims;
       req.session.passportSessionId = passportSessionId;
 
       return next();

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -51,22 +51,6 @@ describe("oauth middleware", () => {
 
     afterEach(() => sandbox.restore());
 
-    it("should save authParams to session", async function () {
-      await middleware.decryptJWTAuthorizeRequest(req, res, next);
-
-      sandbox.assert.calledWith(
-        axios.post,
-        "https://example.org/subpath/initialise-session",
-        "someToken",
-        {
-          headers: {
-            client_id: "s6BhdRkqt3",
-          },
-        }
-      );
-      expect(req.session.JWTData.authParams).to.deep.equal(authParams);
-    });
-
     it("should call next", async function () {
       await middleware.decryptJWTAuthorizeRequest(req, res, next);
       expect(next).to.have.been.called;
@@ -111,7 +95,7 @@ describe("oauth middleware", () => {
     it("should save sharedClaims to session", async function () {
       await middleware.decryptJWTAuthorizeRequest(req, res, next);
 
-      expect(req.session.JWTData.shared_claims).to.deep.equal(sharedClaims);
+      expect(req.session.shared_claims).to.deep.equal(sharedClaims);
     });
 
     it("should call next", async function () {

--- a/src/app/passport/controllers/root.js
+++ b/src/app/passport/controllers/root.js
@@ -2,7 +2,7 @@ const { Controller: BaseController } = require("hmpo-form-wizard");
 
 class RootController extends BaseController {
   async saveValues(req, res, next) {
-    const sharedClaims = req.session?.JWTData?.shared_claims;
+    const sharedClaims = req.session?.shared_claims;
 
     if (sharedClaims) {
       if (sharedClaims?.names?.length > 0) {

--- a/src/app/passport/controllers/root.test.js
+++ b/src/app/passport/controllers/root.test.js
@@ -24,15 +24,13 @@ describe("root controller", () => {
         client_id: "s6BhdRkqt3",
       },
       session: {
-        JWTData: {
-          shared_claims: {
-            names: [
-              { givenNames: ["Dan John"], familyName: "Watson" },
-              { givenNames: ["Daniel"], familyName: "Watson" },
-              { givenNames: ["Danny, Dan"], familyName: "Watson" },
-            ],
-            dateOfBirths: ["2021-03-01", "1991-03-01"],
-          },
+        shared_claims: {
+          names: [
+            { givenNames: ["Dan John"], familyName: "Watson" },
+            { givenNames: ["Daniel"], familyName: "Watson" },
+            { givenNames: ["Danny, Dan"], familyName: "Watson" },
+          ],
+          dateOfBirths: ["2021-03-01", "1991-03-01"],
         },
       },
       sessionModel: {
@@ -59,22 +57,22 @@ describe("root controller", () => {
 
     expect(req.journeyModel.set.getCall(0).args[0]).to.eq("surname");
     expect(req.journeyModel.set.getCall(0).args[1]).to.eq(
-      req.session.JWTData.shared_claims.names[0].familyName
+      req.session.shared_claims.names[0].familyName
     );
 
     expect(req.journeyModel.set.getCall(1).args[0]).to.eq("givenNames");
     expect(req.journeyModel.set.getCall(1).args[1]).to.eq(
-      req.session.JWTData.shared_claims.names[0].givenNames
+      req.session.shared_claims.names[0].givenNames
     );
 
     expect(req.journeyModel.set.getCall(2).args[0]).to.eq("dateOfBirth");
     expect(req.journeyModel.set.getCall(2).args[1]).to.eq(
-      req.session.JWTData.shared_claims.dateOfBirths[0]
+      req.session.shared_claims.dateOfBirths[0]
     );
   });
 
   it("should not update journeyModel if no shared attributes present", async () => {
-    req.session.JWTData.shared_claims = {
+    req.session.shared_claims = {
       names: [],
       dateOfBirths: [],
     };


### PR DESCRIPTION
### What changed
Stop storing authParams in session, store only shared_claims


- [PYIC-1610](https://govukverify.atlassian.net/browse/PYIC-1610)
