### PR TITLE
BAU: Update frontend logging to use correct passportSessionId

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -28,10 +28,10 @@ const loggerConfig = {
   consoleJSON: true,
   app: false,
   requestMeta: {
-    passportSessionId: "session.id",
+    passportSessionId: "session.passportSessionId",
   },
   meta: {
-    passportSessionId: "session.id",
+    passportSessionId: "session.passportSessionId",
   },
 };
 


### PR DESCRIPTION
## Proposed changes

### What changed

Update the logging config to use the value stored in `session.passportSessionId` when adding `passportSessionId` to logs.

### Why did it change

The passportSessionId was previously the same as the frontend session. With the updates to the passport cri to enable retrying passport entry, we have updated the session model such that passport back has its own session that is shared with passport front.

Passport front was still logging its session.id as the passportSessionId. 
