### PR TITLE
PYIC 1645 prove identity another way

### DIFF
--- a/src/app/passport/controllers/prove-another-way.js
+++ b/src/app/passport/controllers/prove-another-way.js
@@ -1,5 +1,7 @@
 const BaseController = require("hmpo-form-wizard").Controller;
 const axios = require("axios");
+const logger = require("hmpo-logger").get();
+
 const {
   API_BUILD_CLIENT_OAUTH_RESPONSE_PATH,
   API_BASE_URL,
@@ -8,6 +10,7 @@ const {
 class ProveAnotherWayController extends BaseController {
   async saveValues(req, res, next) {
     try {
+      logger.info("user submitting prove another way", { req, res });
       const action = req.form.values.proveAnotherWayRadio;
 
       const headers = {
@@ -16,6 +19,10 @@ class ProveAnotherWayController extends BaseController {
 
       switch (action) {
         case "proveAnotherWay": {
+          logger.info(
+            "user selected prove another way : calling build-client-oauth-response lambda",
+            { req, res }
+          );
           const apiResponse = await axios.post(
             `${API_BASE_URL}${API_BUILD_CLIENT_OAUTH_RESPONSE_PATH}`,
             undefined,
@@ -28,6 +35,10 @@ class ProveAnotherWayController extends BaseController {
           return "/oauth2/callback";
         }
         case "retry": {
+          logger.info("user selected retry : redirecting to passport details", {
+            req,
+            res,
+          });
           return next();
         }
       }

--- a/src/app/passport/controllers/prove-another-way.js
+++ b/src/app/passport/controllers/prove-another-way.js
@@ -27,6 +27,9 @@ class ProveAnotherWayController extends BaseController {
           super.saveValues(req, res);
           return "/oauth2/callback";
         }
+        case "retry": {
+          return next();
+        }
       }
     } catch (err) {
       if (err) {

--- a/src/app/passport/controllers/prove-another-way.js
+++ b/src/app/passport/controllers/prove-another-way.js
@@ -11,6 +11,8 @@ class ProveAnotherWayController extends BaseController {
   async saveValues(req, res, next) {
     try {
       logger.info("user submitting prove another way", { req, res });
+      req.sessionModel.set("redirect_url", undefined);
+
       const action = req.form.values.proveAnotherWayRadio;
 
       const headers = {

--- a/src/app/passport/controllers/prove-another-way.js
+++ b/src/app/passport/controllers/prove-another-way.js
@@ -1,16 +1,31 @@
 const BaseController = require("hmpo-form-wizard").Controller;
+const axios = require("axios");
+const {
+  API_BUILD_CLIENT_OAUTH_RESPONSE_PATH,
+  API_BASE_URL,
+} = require("../../../lib/config");
 
 class ProveAnotherWayController extends BaseController {
   async saveValues(req, res, next) {
     try {
       const action = req.form.values.proveAnotherWayRadio;
 
+      const headers = {
+        passport_session_id: req.session.passportSessionId,
+      };
+
       switch (action) {
         case "proveAnotherWay": {
-          break;
-        }
-        case "retry": {
-          break;
+          const apiResponse = await axios.post(
+            `${API_BASE_URL}${API_BUILD_CLIENT_OAUTH_RESPONSE_PATH}`,
+            undefined,
+            { headers: headers }
+          );
+
+          const redirect_url = apiResponse?.data?.client?.redirectUrl;
+          req.sessionModel.set("redirect_url", redirect_url);
+          super.saveValues(req, res);
+          return "/oauth2/callback";
         }
       }
     } catch (err) {

--- a/src/app/passport/controllers/prove-another-way.js
+++ b/src/app/passport/controllers/prove-another-way.js
@@ -1,0 +1,24 @@
+const BaseController = require("hmpo-form-wizard").Controller;
+
+class ProveAnotherWayController extends BaseController {
+  async saveValues(req, res, next) {
+    try {
+      const action = req.form.values.proveAnotherWayRadio;
+
+      switch (action) {
+        case "proveAnotherWay": {
+          break;
+        }
+        case "retry": {
+          break;
+        }
+      }
+    } catch (err) {
+      if (err) {
+        return next(err);
+      }
+    }
+  }
+}
+
+module.exports = ProveAnotherWayController;

--- a/src/app/passport/controllers/prove-another-way.test.js
+++ b/src/app/passport/controllers/prove-another-way.test.js
@@ -63,6 +63,8 @@ describe("prove another way controller", () => {
 
   it("should not store redirect_url in session when users selects retry", async () => {
     req.session.passportSessionId = "passport123";
+    req.sessionModel.set("redirect_url", "url");
+
     req.form = {
       values: {
         proveAnotherWayRadio: "retry",

--- a/src/app/passport/controllers/prove-another-way.test.js
+++ b/src/app/passport/controllers/prove-another-way.test.js
@@ -1,0 +1,97 @@
+const BaseController = require("hmpo-form-wizard").Controller;
+const ProveAnotherWayController = require("./prove-another-way");
+const axios = require("axios");
+
+describe("prove another way controller", () => {
+  const proveAnotherWayController = new ProveAnotherWayController({
+    route: "/test",
+  });
+
+  let req;
+  let res;
+  let next;
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    const setup = setupDefaultMocks();
+    req = setup.req;
+    res = setup.res;
+    next = setup.next;
+  });
+  afterEach(() => sandbox.restore());
+
+  it("should be an instance of BaseController", () => {
+    expect(proveAnotherWayController).to.be.an.instanceOf(BaseController);
+  });
+
+  it("should store redirect_url in session when users selects proveAnotherWay", async () => {
+    const passportSessionId = "passport123";
+    req.session.passportSessionId = passportSessionId;
+    req.form = {
+      values: {
+        proveAnotherWayRadio: "proveAnotherWay",
+      },
+    };
+
+    const data = {
+      client: {
+        redirectUrl:
+          "https://client.example.com/cb?id=PassportIssuer&code=1234",
+      },
+    };
+
+    const resolvedPromise = new Promise((resolve) => resolve({ data }));
+    sandbox.stub(axios, "post").returns(resolvedPromise);
+
+    await proveAnotherWayController.saveValues(req, res, next);
+
+    sandbox.assert.calledWith(
+      axios.post,
+      sinon.match("/build-client-oauth-response"),
+      undefined,
+      {
+        headers: {
+          passport_session_id: passportSessionId,
+        },
+      }
+    );
+    expect(req.session.test.redirect_url).to.eq(
+      "https://client.example.com/cb?id=PassportIssuer&code=1234"
+    );
+  });
+
+  it("should not store redirect_url in session when users selects retry", async () => {
+    req.session.passportSessionId = "passport123";
+    req.form = {
+      values: {
+        proveAnotherWayRadio: "retry",
+      },
+    };
+
+    const data = {
+      client: {
+        redirectUrl:
+          "https://client.example.com/cb?id=PassportIssuer&code=1234",
+      },
+    };
+
+    const resolvedPromise = new Promise((resolve) => resolve({ data }));
+    sandbox.stub(axios, "post").returns(resolvedPromise);
+
+    await proveAnotherWayController.saveValues(req, res, next);
+
+    expect(req.session.test.redirect_url).to.eq(undefined);
+  });
+
+  it("should return oauth url when sessionModel has a redirect_url value", () => {
+    req.sessionModel.set("redirect_url", "url");
+    const result = proveAnotherWayController.next(req);
+    expect(result).to.eq("/oauth2/callback");
+  });
+
+  it("should return url for passport details value when sessionModel has a redirect_url value", () => {
+    const result = proveAnotherWayController.next(req);
+    expect(result).to.eq("/passport/details");
+  });
+});

--- a/src/app/passport/controllers/validate.js
+++ b/src/app/passport/controllers/validate.js
@@ -29,7 +29,7 @@ class ValidateController extends BaseController {
         passport_session_id: req.session.passportSessionId,
       };
 
-      logger.info("calling check-passport lambda", { req, res });
+      logger.info("validate: calling check-passport lambda", { req, res });
       const checkPassportResponse = await axios.post(
         `${API_BASE_URL}${API_CHECK_PASSPORT_PATH}`,
         attributes,
@@ -37,12 +37,15 @@ class ValidateController extends BaseController {
       );
 
       if (checkPassportResponse.data?.result === "retry") {
-        logger.info("passport retry", { req, res });
+        logger.info("validate: passport retry", { req, res });
         req.sessionModel.set("showRetryMessage", true);
         return callback();
       }
 
-      logger.info("calling build-client-oauth-response lambda", { req, res });
+      logger.info("validate: calling build-client-oauth-response lambda", {
+        req,
+        res,
+      });
       const apiResponse = await axios.post(
         `${API_BASE_URL}${API_BUILD_CLIENT_OAUTH_RESPONSE_PATH}`,
         undefined,
@@ -50,6 +53,10 @@ class ValidateController extends BaseController {
       );
 
       const redirect_url = apiResponse?.data?.client?.redirectUrl;
+      logger.info("Validate: redirecting user to callBack with url ", {
+        req,
+        res,
+      });
 
       super.saveValues(req, res, () => {
         if (!redirect_url) {

--- a/src/app/passport/fields.js
+++ b/src/app/passport/fields.js
@@ -98,4 +98,9 @@ module.exports = {
       },
     ],
   },
+  proveAnotherWayRadio: {
+    type: "radios",
+    items: ["proveAnotherWay", "retry"],
+    validate: ["required"],
+  },
 };

--- a/src/app/passport/steps.js
+++ b/src/app/passport/steps.js
@@ -27,7 +27,7 @@ module.exports = {
     prereqs: ["/passport/"],
     controller: proveAnotherWay,
     fields: ["proveAnotherWayRadio"],
-    next: "details",
+    next: proveAnotherWay.prototype.next,
   },
   "/validate": {
     controller: validate,

--- a/src/app/passport/steps.js
+++ b/src/app/passport/steps.js
@@ -1,7 +1,7 @@
 const details = require("./controllers/details");
 const root = require("./controllers/root");
-
 const validate = require("./controllers/validate");
+const proveAnotherWay = require("./controllers/prove-another-way");
 
 module.exports = {
   "/": {
@@ -22,6 +22,12 @@ module.exports = {
     ],
     controller: details,
     next: "validate",
+  },
+  "/prove-another-way": {
+    prereqs: ["/passport/"],
+    controller: proveAnotherWay,
+    fields: ["proveAnotherWayRadio"],
+    next: "details",
   },
   "/validate": {
     controller: validate,

--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -74,7 +74,7 @@ var cookies = function(trackingId, analyticsCookieDomain, journeyState) {
         'event': "progEvent",
         'ProgrammeName': 'DI - PYI'
       }
-      ];
+    ];
     //var sessionJourney = getJourneyMapping(journeyState);
     function gtag(obj) {
       dataLayer.push(obj);
@@ -85,9 +85,6 @@ var cookies = function(trackingId, analyticsCookieDomain, journeyState) {
         JourneyStatus: journeyState
       })
     }
-    gtag('config', 'GA_MEASUREMENT_ID', {
-      send_page_view: false
-    });
     gtag({
       "gtm.start": new Date().getTime(),
       event: "gtm.js"

--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -85,6 +85,9 @@ var cookies = function(trackingId, analyticsCookieDomain, journeyState) {
         JourneyStatus: journeyState
       })
     }
+    gtag('config', 'GA_MEASUREMENT_ID', {
+      send_page_view: false
+    });
     gtag({
       "gtm.start": new Date().getTime(),
       event: "gtm.js"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -44,7 +44,8 @@ passport:
   title: Enter your details exactly as they appear on your UK passport
   serviceNameRequired: true
   passportInformationContext: Your passport includes a lot of information that we can check to make sure that you are who you say you are.
-  checkDetailsContext: We’ll check your details with the HM Passport Office to make sure your passport has not been cancelled or reported as lost  or stolen.
+  checkDetailsContext: We’ll check your details with the HM Passport Office to make sure your passport has not been cancelled or reported as lost or stolen.
+  passportTryAnotherWay: If you do not have a UK passport or you cannot remember your details, you can <a href="prove-another-way">prove your identity another way</a> instead.
   passportGivenNames: Given names
   retryTitle: Check your details match what’s on your UK passport
   retryWarningLabel: Warning

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -57,3 +57,6 @@ passport:
   retryMessageList2: you’ve entered your first and middle names (‘given names’) in the right sections
   retryMessageList3: you’ve left the middle names section blank if you do not have any middle names
   retryMessageList4: days and months are in the right order in your date of birth and passport expiry date
+
+prove-another-way:
+  title: Prove your identity another way

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -24,7 +24,7 @@ firstName:
 
 middleNames:
   label: Middle names
-  hint: "You do not have to fill this in if you do not have any middle names"
+  hint: "Leave this blank if you do not have any middle names"
   validation:
     maxlength: "Enter your middle names as they appear on your passport"
     regexpassport: "Enter your middle names as they appear on your passport"

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -52,3 +52,15 @@ expiryDate:
 
 "date-year":
   label: Year
+
+proveAnotherWayRadio:
+  label: What would you like to do?
+  validation:
+    required: You must choose an option to continue
+  items:
+    proveAnotherWay:
+      label: Prove your identity another way
+      value: continue
+    retry:
+      label: Try to enter your passport details and prove your identity with a GOV.UK account
+      value: retry

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -1,3 +1,4 @@
+# title is managed in default.yml
 prove-another-way:
   title: Prove your identity another way
   content:

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -1,0 +1,5 @@
+prove-another-way:
+  title: Prove your identity another way
+  content:
+    - You must have a UK passport to prove your identity with a GOV.UK account. If you do not have one or you cannot remember your details, you can prove your identity another way.
+    - This might take you longer than 10 minutes.

--- a/src/views/passport/details.html
+++ b/src/views/passport/details.html
@@ -5,6 +5,7 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% from "hmpo-text/macro.njk" import hmpoText %}
 {% from "hmpo-form/macro.njk" import hmpoForm %}
@@ -54,6 +55,12 @@ classes:'passport-message'
     <p> {{ translate("passport.passportInformationContext") }} </p>
     <p> {{ translate("passport.checkDetailsContext") }}  </p>
 {% endif %}
+
+{{ govukInsetText({
+html: translate("passport.passportTryAnotherWay")
+}) }}
+
+
 
 
     {% call hmpoForm(ctx, {attributes: {onsubmit: 'window.disableFormSubmit()'} }) %}

--- a/src/views/passport/prove-another-way.html
+++ b/src/views/passport/prove-another-way.html
@@ -1,2 +1,2 @@
-{% extends "form-template.njk" %}
+{% extends "shared/ipv-template.html" %}
 {% set hmpoPageKey = "prove-another-way" %}

--- a/src/views/passport/prove-another-way.html
+++ b/src/views/passport/prove-another-way.html
@@ -1,0 +1,2 @@
+{% extends "form-template.njk" %}
+{% set hmpoPageKey = "prove-another-way" %}

--- a/src/views/passport/prove-another-way.html
+++ b/src/views/passport/prove-another-way.html
@@ -1,2 +1,6 @@
 {% extends "shared/ipv-template.html" %}
 {% set hmpoPageKey = "prove-another-way" %}
+
+{% block submitButton %}
+    {{ hmpoSubmit(ctx, {id: 'submitButton'}) }}
+{% endblock %}


### PR DESCRIPTION
## Proposed changes
Add a route for the user to take if they have arrived at the UK Passport CRI but don’t have a UK Passport, or don’t have the details to hand

### What changed

- Added new copy and a link to get to the new prove-another-way route in passport details page.
- Added prove-another-way controller and page that allows a user to select an action


### Issue tracking

- [PYIC-1645](https://govukverify.atlassian.net/browse/PYIC-1645)
- [PYIC-1646](https://govukverify.atlassian.net/browse/PYIC-1646)
- [PYIC-1647](https://govukverify.atlassian.net/browse/PYIC-1647)
- [PYIC-1648](https://govukverify.atlassian.net/browse/PYIC-1648)
- [PYIC-1659](https://govukverify.atlassian.net/browse/PYIC-1659)

