### PR TITLE
PYIC-1696 add class to link for GA consumption

### DIFF
--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -45,7 +45,7 @@ passport:
   serviceNameRequired: true
   passportInformationContext: Your passport includes a lot of information that we can check to make sure that you are who you say you are.
   checkDetailsContext: We’ll check your details with the HM Passport Office to make sure your passport has not been cancelled or reported as lost or stolen.
-  passportTryAnotherWay: If you do not have a UK passport or you cannot remember your details, you can <a href="prove-another-way">prove your identity another way</a> instead.
+  passportTryAnotherWay: If you do not have a UK passport or you cannot remember your details, you can <a href="prove-another-way" class="govuk-link">prove your identity another way</a> instead.
   passportGivenNames: Given names
   retryTitle: Check your details match what’s on your UK passport
   retryWarningLabel: Warning


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This update adds a class to the link users click to use the passport escape.

### What changed

<!-- Describe the changes in detail - the "what"-->
The link has had a class attribute added.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

The GA team uses classes to track user interactions.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1696](https://govukverify.atlassian.net/browse/PYIC-1696) - there is another class to add before this ticket is closed.


