### PR TITLE
PYIC-1696 Add required class to H1s for GA consumption

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "express-session": "^1.17.3",
     "govuk-frontend": "4.0.1",
     "hmpo-app": "2.3.0",
-    "hmpo-components": "5.3.2",
+    "hmpo-components": "5.4.0",
     "hmpo-config": "2.2.1",
     "hmpo-form-wizard": "12.0.5",
     "hmpo-i18n": "5.0.2",

--- a/src/views/errors/error.html
+++ b/src/views/errors/error.html
@@ -2,7 +2,7 @@
 {% set hmpoPageKey = "pages.errors.error" %}
 
 {% block mainContent %}
-<h1 id="header" data-page="{{hmpoPageKey}}">
+<h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
 {{ translate(hmpoPageKey+'.title', { default: [] }) | safe }}
 </h1>
 

--- a/src/views/errors/page-not-found.html
+++ b/src/views/errors/page-not-found.html
@@ -2,7 +2,7 @@
 {% set hmpoPageKey = "pages.errors.pageNotFound" %}
 
 {% block mainContent %}
-<h1 id="header" data-page="{{hmpoPageKey}}">
+<h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
 {{ translate(hmpoPageKey+'.title', { default: [] }) | safe }}
 </h1>
 

--- a/src/views/errors/session-ended.html
+++ b/src/views/errors/session-ended.html
@@ -2,7 +2,7 @@
 {% set hmpoPageKey = "pages.errors.sessionEnded" %}
 
 {% block mainContent %}
-<h1 id="header" data-page="{{hmpoPageKey}}">
+<h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
 {{ translate(hmpoPageKey+'.title', { default: [] }) | safe }}
 </h1>
 

--- a/src/views/passport/details.html
+++ b/src/views/passport/details.html
@@ -15,12 +15,12 @@
 {% block mainContent %}
     {% if values.showRetryMessage and not (ctx("errors") | length) %}
     {# user is retrying #}
-    <h1 class="govuk-heading-l">
+    <h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
         {{ translate("passport.retryTitle") }}
     </h1>
     {% else %}
     {# user's first attempt #}
-    <h1 class="govuk-heading-l">
+    <h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
         {{ translate("passport.title") }}
     </h1>
  {% endif %}

--- a/src/views/passport/prove-another-way.html
+++ b/src/views/passport/prove-another-way.html
@@ -1,6 +1,6 @@
 {% extends "shared/ipv-template.html" %}
 {% set hmpoPageKey = "prove-another-way" %}
-
+{% set hmpoH1Class = "govuk-heading-l" %}
 {% block submitButton %}
     {{ hmpoSubmit(ctx, {id: 'submitButton'}) }}
 {% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This change adds a class of `govuk-heading-l` for all `<h1>` tags within the passport CRI.

### What changed

<!-- Describe the changes in detail - the "what"-->
`package.json` has been updated to require version 5.4.0 of the `hmpo-components` dependency. **This update is required for the change to be visible** on `prove-another-way.html` as this page uses the new `hmpoH1Class` variable in `hmpo-template.njk` in the `hmpo-components` dependency.

Other pages have had their classes changed in the `html` files that generate their source code.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To provide the right configuration for Google Analytics tracking to consume.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1696](https://govukverify.atlassian.net/browse/PYIC-1696) - second item in the checklist.

