### PR TITLE
PYIC-1769 refactor code so all content is managed in yaml files

### DIFF
--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -10,6 +10,9 @@ govuk:
   warning: Warning
   skipLink: Skip to main content
   betaBannerRequired: true
+  betaBannerContent:
+    betaBannerContentLabel: beta
+    betaBannerContentHTML: 'This is a new service – your <a class="govuk-link" rel="noopener" target="_blank" href="https://signin.account.gov.uk/contact-us">feedback (opens in new tab)</a>  will help us to improve it.'
   cookie:
     cookieBanner:
       title: Cookies on GOV.UK account

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -28,7 +28,7 @@ middleNames:
   validation:
     maxlength: "Enter your middle names as they appear on your passport"
     regexpassport: "Enter your middle names as they appear on your passport"
-    firstNameMiddleNameLength: ""
+    firstNameMiddleNameLength: "Enter your first and middle names as they appear on your passport"
 
 dateOfBirth:
   legend: Date of birth

--- a/src/views/shared/banner.njk
+++ b/src/views/shared/banner.njk
@@ -11,11 +11,17 @@
 {% endset %}
 
 {% set acceptHtml %}
-    <p class="govuk-body">{{ 'govuk.cookie.cookieBanner.cookieBannerAccept.paragraph1' | translate }}<a class="govuk-link" href="{{ 'cookieLocation' | trim }}">{{ 'govuk.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'govuk.cookie.cookieBanner.cookieBannerAccept.paragraph2' | translate }}</p>
+    <p class="govuk-body">{{ 'govuk.cookie.cookieBanner.cookieBannerAccept.paragraph1' | translate }}<a
+                class="govuk-link"
+                href="{{ 'cookieLocation' | trim }}">{{ 'govuk.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'govuk.cookie.cookieBanner.cookieBannerAccept.paragraph2' | translate }}
+    </p>
 {% endset %}
 
 {% set rejectedHtml %}
-    <p class="govuk-body">{{ 'govuk.cookie.cookieBanner.cookieBannerReject.paragraph1' | translate }}<a class="govuk-link" href="{{ 'cookieLocation' | trim }}">{{ 'govuk.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'govuk.cookie.cookieBanner.cookieBannerReject.paragraph2' | translate }}</p>
+    <p class="govuk-body">{{ 'govuk.cookie.cookieBanner.cookieBannerReject.paragraph1' | translate }}<a
+                class="govuk-link"
+                href="{{ 'cookieLocation' | trim }}">{{ 'govuk.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'govuk.cookie.cookieBanner.cookieBannerReject.paragraph2' | translate }}
+    </p>
 {% endset %}
 
 {{ govukCookieBanner({
@@ -77,7 +83,7 @@
                 type: "button",
                 classes:"cookie-hide-button",
                 attributes: {
-                "aria-label": "Hide cookie banner button"
+                "aria-label": 'govuk.cookie.cookieBanner.cookieBannerHideLink' | translate
             }
             }
         ],

--- a/src/views/shared/ipv-template.html
+++ b/src/views/shared/ipv-template.html
@@ -33,8 +33,8 @@
 {# the BETA banner is added to all pages using this template by default #}
 {% block beforeContent %}
     {{ govukPhaseBanner({
-    tag: { text: "beta" },
-    html: 'This is a new service – your <a class="govuk-link" rel="noopener" target="_blank" href="https://signin.account.gov.uk/contact-us">feedback (opens in new tab)</a>  will help us to improve it.'
+        tag: { text: translate("govuk.betaBannerContent.betaBannerContentLabel") },
+        html: translate("govuk.betaBannerContent.betaBannerContentHTML")
     }) }}
 {% endblock %}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR ensures that all translatable content in the user interface is managed in the files in `locales/en` for translation into other languages

### What changed

<!-- Describe the changes in detail - the "what"-->
English text present in nunjucks or html files have been shifted into the relevant yaml file.

### Why did it change

So the yaml file holds all the content for the UI, making it easier to manage translations.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1769](https://govukverify.atlassian.net/browse/PYIC-1769)

