### PR TITLE
PYIC-1876 Add Welsh language translation yaml files

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -1,0 +1,64 @@
+buttons:
+  authorizeAndReturn: "Awdurdodi a Dychwelyd"
+  next: "Parhau"
+  cancel: "Canslo"
+govuk:
+  serviceName: " "
+  backLink: "Yn ôl"
+  errorSummaryTitle: "Mae problem"
+  error: "Gwall"
+  warning: "Rhybudd"
+  skipLink: "Neidio i'r prif gynnwys"
+  betaBannerRequired: true
+  betaBannerContent:
+    betaBannerContentLabel: "beta"
+    betaBannerContentHTML: 'Mae hwn yn wasanaeth newydd – bydd eich <a class="govuk-link" rel="noopener" target="_blank" href="https://signin.account.gov.uk/contact-us">adborth (agor mewn tab newydd)</a>  yn ein helpu i''w wella.'
+  cookie:
+    cookieBanner:
+      title: "Cwcis ar gyfrif GOV.UK"
+      heading: "Cwcis ar gyfrif GOV.UK"
+      paragraph1: "Rydym yn defnyddio rhai cwcis hanfodol i wneud i'r gwasanaeth hwn weithio."
+      paragraph2: "Hoffem osod cwcis ychwanegol er mwyn i ni allu cofio eich gosodiadau, deall sut rydych yn defnyddio'r gwasanaeth a gwneud gwelliannau."
+      changeCookiePreferencesLink: "newid eich gosodiadau cwcis"
+      cookieBannerAccept:
+        paragraph1: "Rydych wedi derbyn cwcis ychwanegol. Gallwch "
+        paragraph2: " unrhyw bryd."
+      cookieBannerReject:
+        paragraph1: "Rydych wedi gwrthod cwcis ychwanegol. Gallwch "
+        paragraph2: " unrhyw bryd."
+      buttonAcceptText: "Derbyn cwcis dadansoddi"
+      buttonRejectText: "Gwrthod cwcis dadansoddi"
+      linkViewCookies: "Gweld cwcis"
+      cookieBannerHideLink: "Cuddio'r neges yma"
+  footerNavItems:
+    meta:
+      items:
+        - href: "https://signin.account.gov.uk/accessibility-statement"
+          text: "Datganiad hygyrchedd"
+        - href: "https://signin.account.gov.uk/cookies"
+          text: "Cwcis"
+        - href: "https://signin.account.gov.uk/terms-and-conditions"
+          text: "Telerau ac amodau"
+        - href: "https://signin.account.gov.uk/privacy-notice"
+          text: "Hysbysiad preifatrwydd"
+        - href: "https://signin.account.gov.uk/contact-us"
+          text: "Cymorth"
+passport:
+  title: "Rhowch eich manylion yn union fel maent yn ymddangos ar eich pasbort y DU"
+  serviceNameRequired: true
+  passportInformationContext: "Mae eich pasbort yn cynnwys llawer o wybodaeth y gallwn ei wirio i sicrhau mai chi yw pwy rydych yn ei ddweud ydych chi."
+  checkDetailsContext: "Byddwn yn gwirio'ch manylion gyda Swyddfa Basbort EM i wneud yn siwr nad yw eich pasbort wedi'i ganslo na'i hysbysu fel wedi'i golli neu ei ddwyn."
+  passportTryAnotherWay: 'Os nad oes gennych basbort y DU neu os na allwch gofio''ch manylion, gallwch <a href="prove-another-way" class="govuk-link">brofi pwy ydych chi mewn ffordd arall</a> yn lle hynny.'
+  passportGivenNames: "Enwau a roddwyd"
+  retryTitle: "Gwiriwch bod eich manylion yn cyfateb i'r hyn sydd ar eich pasbort y DU"
+  retryWarningLabel: "Rhybudd"
+  retryWarningText: "Ni fyddwch yn gallu newid eich manylion eto os gwnewch gamgymeriad y tro hwn"
+  retryMessageHeading: "Nid oeddem yn gallu ddod o hyd i'ch manylion"
+  retryMessageParagraph1: "Roedd problem pan wnaethom wirio'ch manylion gyda Swyddfa Pasbort EM."
+  retryMessageParagraph2: "Edrychwch dros eich manylion eto. Cofiwch wneud yn siwr:"
+  retryMessageList1: "bod eich pasbort yn basbort y DU"
+  retryMessageList2: "rydych wedi rhoi eich enwau cyntaf a chanol ('enwau a roddwydl') yn yr adrannau cywir"
+  retryMessageList3: "rydych wedi gadael yr adran enwau canol yn wag os nad oes gennych unrhyw enwau canol"
+  retryMessageList4: "mae'r dyddiau a misoedd yn y drefn gywir yn eich dyddiad geni a phasbort yn dod i ben"
+prove-another-way:
+  title: "Profi pwy ydych chi mewn ffordd arall"

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -1,0 +1,57 @@
+passportNumber:
+  label: "Rhif pasbort"
+  hint: "Dyma'r rhif 9 digid yng nghornel dde uchaf y dudalen llun yn eich pasbort"
+  validation:
+    default: "Rhowch y rhif fel y mae'n ymddangos ar eich pasbort"
+    exactlength: "Dylai rhif eich pasbort fod yn 9 digid o hyd"
+    numeric: "Ni ddylai rhif eich pasbort gynnwys llythrennau na symbolau"
+    limit: "Nid yw rhifau pasbort yn dechrau gyda 9 - rhowch y rhif fel mae'n ymddangos ar eich pasbort"
+surname:
+  label: "Cyfenw"
+  validation:
+    default: "Rhowch eich cyfenw fel mae'n ymddangos ar eich pasbort"
+    maxlength: "Rhowch eich cyfenw fel mae'n ymddangos ar eich pasbort"
+    regexpassport: "Rhowch eich cyfenw fel mae'n ymddangos ar eich pasbort"
+firstName:
+  label: "Enw cyntaf"
+  validation:
+    default: "Rhowch eich enw cyntaf fel mae'n ymddangos ar eich pasbort"
+    maxlength: "Rhowch eich enw cyntaf fel mae'n ymddangos ar eich pasbort"
+    regexpassport: "Rhowch eich enw cyntaf fel mae'n ymddangos ar eich pasbort"
+    firstNameMiddleNameLength: "Rhowch eich enw cyntaf a chanol fel maent yn ymddangos ar eich pasbort"
+middleNames:
+  label: "Enwau canol"
+  hint: "Gadewch hyn yn wag os nad oes gennych unrhyw enwau canol"
+  validation:
+    maxlength: "Rhowch eich enwau canol fel maent yn ymddangos ar eich pasbort"
+    regexpassport: "Rhowch eich enwau canol fel maent yn ymddangos ar eich pasbort"
+    firstNameMiddleNameLength: ""
+dateOfBirth:
+  legend: "Dyddiad geni"
+  hint: "Er enghraifft, 5 9 1973"
+  validation:
+    default: "Rhowch eich dyddiad geni fel mae'n ymddangos ar eich pasbort"
+    before: "Rhaid i'ch dyddiad geni fod yn y gorffennol"
+expiryDate:
+  legend: "Dyddiad dod i ben"
+  hint: "Er enghraifft, 27 5 2029"
+  validation:
+    default: "Rhowch y dyddiad dod i ben fel mae'n ymddangos ar eich pasbort"
+    after: "Mae'n rhaid i'ch pasbort fod heb wedi dod i ben dros 18 mis yn ôl"
+date-day:
+  label: "Diwrnod"
+date-month:
+  label: "Mis"
+date-year:
+  label: "Blwyddyn"
+proveAnotherWayRadio:
+  label: "Beth hoffech chi ei wneud?"
+  validation:
+    required: "Mae'n rhaid i chi ddewis opsiwn i barhau"
+  items:
+    proveAnotherWay:
+      label: "Profi pwy ydych chi mewn ffordd arall"
+      value: "parhau"
+    retry:
+      label: "Ceisiwch roi manylion eich pasbort a phrofi pwy ydych chi gyda chyfrif GOV.UK"
+      value: "ail gynnig"

--- a/src/locales/cy/pages.errors.yml
+++ b/src/locales/cy/pages.errors.yml
@@ -1,0 +1,21 @@
+error:
+  title: "Mae'n ddrwg gennym, mae problem"
+  serviceNameRequired: false
+  content:
+    - "Ni allwn brofi pwy ydych chi ar hyn o bryd."
+    - '<h2 class="govuk-heading-m"> Beth allwch chi ei wneud </h2>'
+    - "Ewch yn ôl i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio'ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK."
+    - '<a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button"> Ewch i hafan GOV.UK </a>'
+    - '<a href="https://signin.account.gov.uk/contact-us" class="govuk-link"> Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd) </a>'
+pageNotFound:
+  title: "Tudalen heb ei darganfod"
+  serviceNameRequired: false
+  content:
+    - "Os ydych wedi teipio'r cyfeiriad gwe, edrychwch i weld ei fod yn gywir."
+    - "Os ydych wedi gludo'r cyfeiriad gwe, edrychwch i weld eich bod wedi copïo'r cyfeiriad cyfan."
+    - "Gallwch hefyd fynd yn ôl i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio'ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK."
+    - '<a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Ewch i hafan GOV.UK</a>'
+    - '<a href="https://signin.account.gov.uk/contact-us" class="govuk-link">Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)</a>'
+sessionEnded:
+  title: "Sesiwn wedi dod i ben"
+  serviceNameRequired: false

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -1,0 +1,5 @@
+prove-another-way:
+  title: "Profi pwy ydych chi mewn ffordd arall"
+  content:
+    - "Mae'n rhaid cael pasbort y DU i brofi pwy ydych chi gyda chyfrif GOV.UK. Os nad oes gennych un neu os na allwch gofio eich manylion, gallwch brofi pwy ydych chi mewn ffordd arall."
+    - "Efallai y bydd hyn yn cymryd mwy na 10 munud i chi."


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR adds Welsh language support for the passport form CRI.

### What changed

<!-- Describe the changes in detail - the "what"-->
4 yaml files are added to `locales/cy` which contain the equivalent content for the information in the `locales/en` folder, including the form fields, error messages, and user interface.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Welsh translation is required for the service to pass service evaluation.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1876](https://govukverify.atlassian.net/browse/PYIC-1876)

