### PR TITLE
LIME-127 Expect an OAuth response after check passport sequence is fi…

### DIFF
--- a/src/app/passport/controllers/validate.js
+++ b/src/app/passport/controllers/validate.js
@@ -4,7 +4,6 @@ const BaseController = require("hmpo-form-wizard").Controller;
 const {
   API_BASE_URL,
   API_CHECK_PASSPORT_PATH,
-  API_BUILD_CLIENT_OAUTH_RESPONSE_PATH,
 } = require("../../../lib/config");
 const logger = require("hmpo-logger").get();
 
@@ -42,17 +41,7 @@ class ValidateController extends BaseController {
         return callback();
       }
 
-      logger.info("validate: calling build-client-oauth-response lambda", {
-        req,
-        res,
-      });
-      const apiResponse = await axios.post(
-        `${API_BASE_URL}${API_BUILD_CLIENT_OAUTH_RESPONSE_PATH}`,
-        undefined,
-        { headers: headers }
-      );
-
-      const redirect_url = apiResponse?.data?.client?.redirectUrl;
+      const redirect_url = checkPassportResponse?.data?.client?.redirectUrl;
       logger.info("Validate: redirecting user to callBack with url ", {
         req,
         res,

--- a/src/app/passport/controllers/validate.test.js
+++ b/src/app/passport/controllers/validate.test.js
@@ -65,16 +65,6 @@ describe("validate controller", () => {
         },
       }
     );
-    sandbox.assert.calledWith(
-      axios.post,
-      sinon.match("/build-client-oauth-response"),
-      undefined,
-      {
-        headers: {
-          passport_session_id: passportSessionId,
-        },
-      }
-    );
     expect(req.session.test.redirect_url).to.eq(
       "https://client.example.com/cb?id=PassportIssuer&code=1234"
     );


### PR DESCRIPTION
## Proposed changes

### What changed

Changed ValidateController to expect an automatic oath response when checkpassport sequence is finished.

### Why did it change

BuildClientOauthResponse lambda is disabled in the passport back template.
Checkpassport Lambda can now return the response automatically.

Merge with LIME-127 in Passport-Back.

### Issue tracking

[LIME-127](https://govukverify.atlassian.net/browse/LIME-127)
[LIME-109](https://govukverify.atlassian.net/browse/LIME-109)