### PR TITLE
LIME-131 Switch to hardcoded APIGatewayIds to unblock passport-back p…

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -60,6 +60,12 @@ Mappings:
     PrefixListIds:
       dynamodb: "pl-b3a742da"
       s3: "pl-7ca54015"
+  IPVCriUkPassportPrivateAPIGatewayID:
+    Environment:
+      build: "ctddhpklrg"
+      staging: "cv2x6jkq8j"
+      integration: "z0bs9the7l"
+      production: "k334qwfoil"
 
 Resources:
   # Security Groups for the ECS service and load balancer
@@ -356,8 +362,7 @@ Resources:
             - Name: API_BASE_URL
               Value: !Sub
                 - "https://${APIGatewayId}.execute-api.eu-west-2.amazonaws.com/${Environment}"
-                - APIGatewayId:
-                    Fn::ImportValue: !Sub IPVCriUkPassportPrivateAPIGatewayID-${Environment}
+                - APIGatewayId: !FindInMap [IPVCriUkPassportPrivateAPIGatewayID, Environment, !Ref Environment]
             - Name: SESSION_TABLE_NAME
               Value: !Sub
                 - "cri-passport-front-sessions-${Environment}"


### PR DESCRIPTION
## Proposed changes

### What changed

Use hardcoded passport api gateway ids.

### Why did it change

To allow overwriting the values in passport back build pipeline.

### Issue tracking
- [LIME-131](https://govukverify.atlassian.net/browse/LIME-131)