### PR TITLE
LIME-131 Switch APIGatewayID back to imported value

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -60,12 +60,6 @@ Mappings:
     PrefixListIds:
       dynamodb: "pl-b3a742da"
       s3: "pl-7ca54015"
-  IPVCriUkPassportPrivateAPIGatewayID:
-    Environment:
-      build: "ctddhpklrg"
-      staging: "cv2x6jkq8j"
-      integration: "z0bs9the7l"
-      production: "k334qwfoil"
 
 Resources:
   # Security Groups for the ECS service and load balancer
@@ -362,7 +356,8 @@ Resources:
             - Name: API_BASE_URL
               Value: !Sub
                 - "https://${APIGatewayId}.execute-api.eu-west-2.amazonaws.com/${Environment}"
-                - APIGatewayId: !FindInMap [IPVCriUkPassportPrivateAPIGatewayID, Environment, !Ref Environment]
+                - APIGatewayId:
+                    Fn::ImportValue: !Sub IPVCriUkPassportPrivateAPIGatewayID-${Environment}
             - Name: SESSION_TABLE_NAME
               Value: !Sub
                 - "cri-passport-front-sessions-${Environment}"


### PR DESCRIPTION
## What changed

Restore passport back private api to an imported value.

## Why did it change

Restoring use of imported GatewayIds.

## Issue tracking
[LIME-131](https://govukverify.atlassian.net/browse/LIME-131)