### PR TITLE
Removing-CSLS-Rust: Removed the old rust log endpoints

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -332,14 +332,6 @@ Resources:
       RetentionInDays: 14
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
-  ECSAccessLogsGroupSubscriptionFilter:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
-      FilterPattern: ""
-      LogGroupName: !Ref ECSAccessLogsGroup
-
   ECSAccessLogsGroupSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevelopment
@@ -529,14 +521,6 @@ Resources:
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
       RetentionInDays: 14
 
-  APIGWAccessLogsGroupSubscriptionFilter:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
-      FilterPattern: ""
-      LogGroupName: !Ref APIGWAccessLogsGroup
-  
   APIGWAccessLogsGroupSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevelopment


### PR DESCRIPTION
## Proposed changes

### What changed

Removed old prod log subscription

### Why did it change

Because the old endpoint is being decommissioned

