### PR TITLE
LIME-404 - Changed account team to One Login

### DIFF
--- a/src/locales/en/pages.errors.yml
+++ b/src/locales/en/pages.errors.yml
@@ -6,7 +6,7 @@ error:
     - <h2 class="govuk-heading-m"> What you can do </h2>
     - Go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button"> Go the GOV.UK homepage </a>
-    - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link"> Contact the GOV.UK account team (opens in a new tab) </a>
+    - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link"> Contact the GOV.UK One Login (opens in a new tab) </a>
 
 pageNotFound:
   title: Page not found
@@ -16,7 +16,7 @@ pageNotFound:
     - If you pasted the web address, check you copied the entire address.
     - You can also go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Go to the GOV.UK homepage</a>
-    - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
+    - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK One Login (opens in a new tab)</a>
 
 sessionEnded:
   title: Session expired


### PR DESCRIPTION
### What changed

Changed the product name on error page from GOV.UK Account team to GOV.UK One Login.
