### PR TITLE
LIME-250 Add language choice analytics

### DIFF
--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -58,6 +58,27 @@ var cookies = function(trackingId, analyticsCookieDomain, journeyState) {
     initGtm();
     initLinkerHandlers();
   }
+
+  function pushLanguageToDataLayer() {
+
+    var languageNames = {
+      'en':'english',
+      'cy':'welsh'
+    }
+
+    var languageCode = document.querySelector('html') &&
+      document.querySelector('html').getAttribute('lang');
+
+    if (languageCode) {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: "langEvent",
+        language: languageNames[languageCode],
+        languagecode: languageCode
+      });
+    }
+  }
+
   function loadGtmScript() {
     var gtmScriptTag = document.createElement("script");
     gtmScriptTag.type = "text/javascript";
@@ -85,6 +106,7 @@ var cookies = function(trackingId, analyticsCookieDomain, journeyState) {
         JourneyStatus: journeyState
       })
     }
+    pushLanguageToDataLayer();
     gtag({
       "gtm.start": new Date().getTime(),
       event: "gtm.js"


### PR DESCRIPTION
## Proposed changes

Send the user’s language choice to Google Analytics

### What changed

Replicating the PR https://github.com/alphagov/di-ipv-cri-common-express/pull/168 in common-express

Which replicates the implementation found in core-front.

https://github.com/alphagov/di-ipv-core-front/commit/7feea5893e98b9b3083d5e8d14189100b1cd4d5a

https://github.com/alphagov/di-authentication-frontend/commit/74ebe4d7c64ea5643d387ee947dc0c6dc44eac5c

https://github.com/alphagov/di-ipv-core-front/pull/572

### Why did it change

To track users language choice.

### Issue tracking

- [LIME-250](https://govukverify.atlassian.net/browse/LIME-250)
 

[LIME-250]: https://govukverify.atlassian.net/browse/LIME-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ