### PR TITLE
LIME-648: Allow passport front github actions to be manually triggered

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: # deploy manually
 
 jobs:
   dockerBuildAndPush:


### PR DESCRIPTION
## Proposed changes

### What changed

Allowing builds to be triggered manually

### Why did it change

To unblock the test step in the pipeline

